### PR TITLE
Prep for two connections

### DIFF
--- a/migrator/db.py
+++ b/migrator/db.py
@@ -4,21 +4,22 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from migrator.extensions import config
+from migrator.models import CdnBase
 
 cdn_engine = create_engine(config.CDN_BROKER_DATABASE_URI)
-CdnSession = sessionmaker(bind=cdn_engine)
+Session = sessionmaker(binds={CdnBase: cdn_engine})
 
 
 @contextmanager
-def cdn_session_handler():
-    session = CdnSession()
+def session_handler():
+    session = Session()
     try:
         yield session
     finally:
         session.close()
 
 
-def check_connections(cdn_session_maker=CdnSession):
-    cdn_session = cdn_session_maker()
-    cdn_session.execute("SELECT 1 FROM certificates")
-    cdn_session.close()
+def check_connections(session_maker=Session, cdn_binding=cdn_engine):
+    session = session_maker()
+    session.execute("SELECT 1 FROM certificates", bind=cdn_binding)
+    session.close()

--- a/migrator/models.py
+++ b/migrator/models.py
@@ -3,10 +3,10 @@ from sqlalchemy.ext import declarative
 from sqlalchemy.dialects import postgresql
 from sqlalchemy import orm
 
-Base = declarative.declarative_base()
+CdnBase = declarative.declarative_base()
 
 
-class CdnUserData(Base):
+class CdnUserData(CdnBase):
     """
     CdnUserData is about the Let's Encrypt user associated with a CdnRoute.
     We probably have no reason to ever think about this model in this project.
@@ -23,7 +23,7 @@ class CdnUserData(Base):
     key = sa.Column(postgresql.BYTEA)
 
 
-class CdnRoute(Base):
+class CdnRoute(CdnBase):
     """
     CdnRoute represents the core of the service instance
     """
@@ -54,7 +54,7 @@ class CdnRoute(Base):
     state = sa.Column(sa.Text)
 
 
-class CdnCertificate(Base):
+class CdnCertificate(CdnBase):
     __tablename__ = "certificates"
 
     id = sa.Column(sa.Integer, primary_key=True)

--- a/tests/lib/database.py
+++ b/tests/lib/database.py
@@ -1,18 +1,18 @@
 import pytest
-from migrator.db import cdn_session_handler
+from migrator.db import session_handler, cdn_engine
 
 
 @pytest.fixture
 def clean_db():
-    with cdn_session_handler() as session:
-        session.execute("TRUNCATE TABLE user_data")
-        session.execute("TRUNCATE TABLE routes")
-        session.execute("TRUNCATE TABLE certificates")
+    with session_handler() as session:
+        session.execute("TRUNCATE TABLE user_data", bind=cdn_engine)
+        session.execute("TRUNCATE TABLE routes", bind=cdn_engine)
+        session.execute("TRUNCATE TABLE certificates", bind=cdn_engine)
         session.commit()
         session.close()
         yield session
-        session.execute("TRUNCATE TABLE user_data")
-        session.execute("TRUNCATE TABLE routes")
-        session.execute("TRUNCATE TABLE certificates")
+        session.execute("TRUNCATE TABLE user_data", bind=cdn_engine)
+        session.execute("TRUNCATE TABLE routes", bind=cdn_engine)
+        session.execute("TRUNCATE TABLE certificates", bind=cdn_engine)
         session.commit()
         session.close()

--- a/tests/unit/test_cdn_db.py
+++ b/tests/unit/test_cdn_db.py
@@ -8,7 +8,9 @@ from migrator import extensions
 
 def test_can_get_session():
     with db.session_handler() as session:
-        result = session.execute("SELECT count(1) FROM certificates", bind=db.cdn_engine)
+        result = session.execute(
+            "SELECT count(1) FROM certificates", bind=db.cdn_engine
+        )
         assert result.first() == (0,)
 
 

--- a/tests/unit/test_cdn_db.py
+++ b/tests/unit/test_cdn_db.py
@@ -7,8 +7,8 @@ from migrator import extensions
 
 
 def test_can_get_session():
-    with db.cdn_session_handler() as session:
-        result = session.execute("SELECT count(1) FROM certificates")
+    with db.session_handler() as session:
+        result = session.execute("SELECT count(1) FROM certificates", bind=db.cdn_engine)
         assert result.first() == (0,)
 
 
@@ -17,7 +17,7 @@ def test_can_create_route():
 
     # note that we shouldn't _actually_ be creating routes in this project
     # but this is a test we can do with an empty database
-    with db.cdn_session_handler() as session:
+    with db.session_handler() as session:
         route = models.CdnRoute()
         route.id = 12345
         route.instance_id = "disposable-route-id"
@@ -35,6 +35,6 @@ def test_check_connections():
     engine = sa.create_engine("postgresql://localhost:1234")
     Session = orm.sessionmaker(bind=engine)
     with pytest.raises(Exception):
-        db.check_connections(cdn_session_maker=Session)
+        db.check_connections(cdn_session_maker=Session, cdn_binding=engine)
 
     db.check_connections()


### PR DESCRIPTION
## Changes proposed in this pull request:

- Rename shared session to indicate it manages both sessions
- pass cdn_engine around as a parameter
- make declarative base name more obvious

## Security considerations

None