### PR TITLE
add cf client and fixtures for testing it

### DIFF
--- a/migrator/config.py
+++ b/migrator/config.py
@@ -40,6 +40,9 @@ class LocalConfig(Config):
         self.CLOUDFRONT_HOSTED_ZONE_ID = "Z2FDTNDATAQYW2"
         self.AWS_POLL_WAIT_TIME_IN_SECONDS = 0.01
         self.AWS_POLL_MAX_ATTEMPTS = 10
+        self.CF_USERNAME = "fake-username"
+        self.CF_PASSWORD = "fake-password"
+        self.CF_API_ENDPOINT = "http://localhost"
 
 
 class AppConfig(Config):
@@ -62,6 +65,9 @@ class AppConfig(Config):
             "AWS_COMMERCIAL_SECRET_ACCESS_KEY"
         )
         self.ROUTE53_ZONE_ID = self.env_parser("ROUTE53_HOSTED_ZONE_ID")
+        self.CF_USERNAME = self.env_parser("CF_USERNAME")
+        self.CF_PASSWORD = self.env_parser("CF_PASSWORD")
+        self.CF_API_ENDPOINT = self.env_parser("CF_API_ENDPOINT")
         self.AWS_POLL_WAIT_TIME_IN_SECONDS = 60
         self.AWS_POLL_MAX_ATTEMPTS = 10
 

--- a/migrator/extensions.py
+++ b/migrator/extensions.py
@@ -1,4 +1,5 @@
 import boto3
+from cloudfoundry_client.client import CloudFoundryClient
 
 from migrator.config import config_from_env
 
@@ -14,3 +15,15 @@ commercial_session = boto3.Session(
 cloudfront = commercial_session.client("cloudfront")
 iam_commercial = commercial_session.client("iam")
 route53 = commercial_session.client("route53")
+
+
+def get_cf_client():
+    # "why is this a function, and the rest of these are static?"
+    # good question. The __init__ on this immediately probes the
+    # api endpoint, which means we need to stub it for testing.
+    # and having to add that stub to every test that _might_
+    # `import extensions` would be bonkers. As a function, we should
+    # only need to stub when we're actually thinking about CF
+    client = CloudFoundryClient(config.CF_API_ENDPOINT)
+    client.init_with_user_credentials(config.CF_USERNAME, config.CF_PASSWORD)
+    return client

--- a/migrator/service_plan.py
+++ b/migrator/service_plan.py
@@ -1,0 +1,6 @@
+def enable_plan_for_org(plan_id, org_id, client):
+    return client.v2.service_plan_visibilities.create(plan_id, org_id)
+
+
+def disable_plan_for_org(plan_id, org_id, client):
+    pass

--- a/pip-tools/dev-requirements.in
+++ b/pip-tools/dev-requirements.in
@@ -6,4 +6,5 @@ pip-tools
 pytest
 pytest-profiling
 pytest-watch
+requests-mock
 requests

--- a/pip-tools/dev-requirements.txt
+++ b/pip-tools/dev-requirements.txt
@@ -4,16 +4,19 @@
 #
 #    ./dev update-requirements
 #
+aiohttp==3.6.2            # via -r pip-tools/../requirements.txt, cloudfoundry-client
 appdirs==1.4.3            # via black
-attrs==19.3.0             # via black, pytest
+async-timeout==3.0.1      # via -r pip-tools/../requirements.txt, aiohttp
+attrs==20.2.0             # via -r pip-tools/../requirements.txt, aiohttp, black, pytest
 black==19.10b0            # via -r pip-tools/dev-requirements.in
 boto3==1.14.48            # via -r pip-tools/../requirements.txt
 botocore==1.17.48         # via -r pip-tools/../requirements.txt, boto3, s3transfer
-certifi==2020.6.20        # via requests
+certifi==2020.6.20        # via -r pip-tools/../requirements.txt, requests
 cfenv==0.5.3              # via -r pip-tools/../requirements.txt
 cffi==1.14.2              # via -r pip-tools/../requirements.txt, cryptography
-chardet==3.0.4            # via requests
+chardet==3.0.4            # via -r pip-tools/../requirements.txt, aiohttp, requests
 click==7.1.1              # via black, pip-tools
+cloudfoundry-client==1.14.1  # via -r pip-tools/../requirements.txt
 colorama==0.4.3           # via pytest-watch
 cryptography==3.1         # via -r pip-tools/../requirements.txt
 dnspython==2.0.0          # via -r pip-tools/../requirements.txt
@@ -23,17 +26,20 @@ environs==8.0.0           # via -r pip-tools/../requirements.txt
 flake8==3.8.2             # via -r pip-tools/dev-requirements.in
 furl==2.1.0               # via -r pip-tools/../requirements.txt, cfenv
 gprof2dot==2019.11.30     # via pytest-profiling
-idna==2.10                # via requests
+idna==2.10                # via -r pip-tools/../requirements.txt, requests, yarl
 jmespath==0.10.0          # via -r pip-tools/../requirements.txt, boto3, botocore
 marshmallow==3.7.1        # via -r pip-tools/../requirements.txt, environs
 mccabe==0.6.1             # via flake8
 more-itertools==8.2.0     # via pytest
+multidict==4.7.6          # via -r pip-tools/../requirements.txt, aiohttp, yarl
+oauth2-client==1.2.1      # via -r pip-tools/../requirements.txt, cloudfoundry-client
 orderedmultidict==1.0.1   # via -r pip-tools/../requirements.txt, furl
 packaging==20.3           # via pytest
 pathspec==0.8.0           # via black
 pathtools==0.1.2          # via watchdog
 pip-tools==5.0.0          # via -r pip-tools/dev-requirements.in
 pluggy==0.13.1            # via pytest
+protobuf==3.6.1           # via -r pip-tools/../requirements.txt, cloudfoundry-client
 psycopg2==2.8.5           # via -r pip-tools/../requirements.txt
 py==1.8.1                 # via pytest
 pycodestyle==2.6.0        # via flake8
@@ -45,10 +51,12 @@ pytest-watch==4.2.0       # via -r pip-tools/dev-requirements.in
 pytest==5.4.1             # via -r pip-tools/dev-requirements.in, pytest-profiling, pytest-watch
 python-dateutil==2.8.1    # via -r pip-tools/../requirements.txt, botocore
 python-dotenv==0.14.0     # via -r pip-tools/../requirements.txt, environs
+pyyaml==5.3.1             # via -r pip-tools/../requirements.txt, cloudfoundry-client
 regex==2020.5.7           # via black
-requests==2.24.0          # via -r pip-tools/dev-requirements.in
+requests-mock==1.8.0      # via -r pip-tools/dev-requirements.in
+requests==2.24.0          # via -r pip-tools/../requirements.txt, -r pip-tools/dev-requirements.in, oauth2-client, requests-mock
 s3transfer==0.3.3         # via -r pip-tools/../requirements.txt, boto3
-six==1.15.0               # via -r pip-tools/../requirements.txt, cryptography, furl, orderedmultidict, packaging, pip-tools, pytest-profiling, python-dateutil, sqlalchemy-utils
+six==1.15.0               # via -r pip-tools/../requirements.txt, cryptography, furl, orderedmultidict, packaging, pip-tools, protobuf, pytest-profiling, python-dateutil, requests-mock, sqlalchemy-utils, websocket-client
 sqlalchemy-utils==0.36.8  # via -r pip-tools/../requirements.txt
 sqlalchemy==1.3.19        # via -r pip-tools/../requirements.txt, sqlalchemy-utils
 toml==0.10.0              # via black
@@ -56,6 +64,9 @@ typed-ast==1.4.1          # via black
 urllib3==1.25.10          # via -r pip-tools/../requirements.txt, botocore, requests
 watchdog==0.10.2          # via pytest-watch
 wcwidth==0.1.9            # via pytest
+websocket-client==0.53.0  # via -r pip-tools/../requirements.txt, cloudfoundry-client
+yarl==1.6.2               # via -r pip-tools/../requirements.txt, aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip
+# setuptools

--- a/pip-tools/requirements.in
+++ b/pip-tools/requirements.in
@@ -1,5 +1,6 @@
 boto3
 cfenv
+cloudfoundry-client
 cryptography
 dnspython
 environs

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,24 +4,41 @@
 #
 #    ./dev update-requirements
 #
+aiohttp==3.6.2            # via cloudfoundry-client
+async-timeout==3.0.1      # via aiohttp
+attrs==20.2.0             # via aiohttp
 boto3==1.14.48            # via -r pip-tools/requirements.in
 botocore==1.17.48         # via boto3, s3transfer
+certifi==2020.6.20        # via requests
 cfenv==0.5.3              # via -r pip-tools/requirements.in
 cffi==1.14.2              # via cryptography
+chardet==3.0.4            # via aiohttp, requests
+cloudfoundry-client==1.14.1  # via -r pip-tools/requirements.in
 cryptography==3.1         # via -r pip-tools/requirements.in
 dnspython==2.0.0          # via -r pip-tools/requirements.in
 docutils==0.15.2          # via botocore
 environs==8.0.0           # via -r pip-tools/requirements.in
 furl==2.1.0               # via cfenv
+idna==2.10                # via requests, yarl
 jmespath==0.10.0          # via boto3, botocore
 marshmallow==3.7.1        # via environs
+multidict==4.7.6          # via aiohttp, yarl
+oauth2-client==1.2.1      # via cloudfoundry-client
 orderedmultidict==1.0.1   # via furl
+protobuf==3.6.1           # via cloudfoundry-client
 psycopg2==2.8.5           # via -r pip-tools/requirements.in
 pycparser==2.20           # via cffi
 python-dateutil==2.8.1    # via botocore
 python-dotenv==0.14.0     # via environs
+pyyaml==5.3.1             # via cloudfoundry-client
+requests==2.24.0          # via oauth2-client
 s3transfer==0.3.3         # via boto3
-six==1.15.0               # via cryptography, furl, orderedmultidict, python-dateutil, sqlalchemy-utils
+six==1.15.0               # via cryptography, furl, orderedmultidict, protobuf, python-dateutil, sqlalchemy-utils, websocket-client
 sqlalchemy-utils==0.36.8  # via -r pip-tools/requirements.in
 sqlalchemy==1.3.19        # via -r pip-tools/requirements.in, sqlalchemy-utils
-urllib3==1.25.10          # via botocore
+urllib3==1.25.10          # via botocore, requests
+websocket-client==0.53.0  # via cloudfoundry-client
+yarl==1.6.2               # via aiohttp
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import pytest
+import requests_mock
+
 from tests.lib.database import clean_db
 from tests.lib.dns import dns
 from tests.lib.fake_cloudfront import cloudfront
@@ -31,3 +34,9 @@ def pytest_collection_modifyitems(items, config):
         print("\nOnly running @pytest.mark.focus tests")
         config.hook.pytest_deselected(items=deselected_items)
         items[:] = selected_items
+
+
+@pytest.fixture
+def fake_requests():
+    with requests_mock.Mocker(real_http=False) as m:
+        yield m

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -74,6 +74,9 @@ def mocked_env(vcap_application, vcap_services, monkeypatch):
     monkeypatch.setenv("AWS_COMMERCIAL_SECRET_ACCESS_KEY", "NOT_A_REAL_SECRET_KEY")
     monkeypatch.setenv("DATABASE_ENCRYPTION_KEY", "NOT_A_REAL_SECRET_KEY")
     monkeypatch.setenv("ROUTE53_HOSTED_ZONE_ID", "FAKEZONEID")
+    monkeypatch.setenv("CF_USERNAME", "fake_cf_username")
+    monkeypatch.setenv("CF_PASSWORD", "fake_cf_password")
+    monkeypatch.setenv("CF_API_ENDPOINT", "https://localhost")
 
 
 @pytest.mark.parametrize("env", ["local", "development", "staging", "production"])
@@ -93,3 +96,6 @@ def test_config_gets_credentials(env, monkeypatch, mocked_env):
     assert config.AWS_COMMERCIAL_ACCESS_KEY_ID == "ASIANOTAREALKEY"
     assert config.AWS_COMMERCIAL_SECRET_ACCESS_KEY == "NOT_A_REAL_SECRET_KEY"
     assert config.ROUTE53_ZONE_ID == "FAKEZONEID"
+    assert config.CF_USERNAME == "fake_cf_username"
+    assert config.CF_PASSWORD == "fake_cf_password"
+    assert config.CF_API_ENDPOINT == "https://localhost"

--- a/tests/unit/test_service_plan.py
+++ b/tests/unit/test_service_plan.py
@@ -1,0 +1,79 @@
+import json
+
+import pytest
+from migrator.extensions import get_cf_client
+from migrator import service_plan
+import requests_mock
+
+
+def get_test_client(fake_requests):
+    fake_requests.get(
+        "http://localhost/info",
+        text=json.dumps(
+            dict(
+                authorization_endpoint="http://login.localhost",
+                token_endpoint="http://token.localhost",
+            )
+        ),
+    )
+    fake_requests.get(
+        "http://localhost/",
+        text=json.dumps(
+            dict(
+                links={
+                    "self": dict(href="localhost"),
+                    "cloud_controller_v2": dict(
+                        href="localhost/v2", meta=dict(version="2.141.0")
+                    ),
+                    "cloud_controller_v3": dict(
+                        href="localhost/v3", meta=dict(version="3.76.0")
+                    ),
+                    "logging": None,
+                    "log_stream": None,
+                    "app_ssh": dict(href="ssh.localhost:80"),
+                    "uaa": dict(href="https://uaa.localhost"),
+                    "network_policy_v0": dict(
+                        href="https://api.localhost/networking/v0/external"
+                    ),
+                    "network_policy_v1": dict(
+                        href="https://api.localhost/networking/v1/external"
+                    ),
+                }
+            )
+        ),
+    )
+    fake_requests.post(
+        "http://login.localhost/oauth/token",
+        text=json.dumps(
+            dict(access_token="access-token", refresh_token="refresh-token")
+        ),
+    )
+    client = get_cf_client()
+    return client
+
+
+def test_get_client(fake_requests):
+    # this test mostly just validates the test framework
+    client = get_test_client(fake_requests)
+
+
+def test_enable_service_plan_2(fake_requests):
+    client = get_test_client(fake_requests)
+    response_body = """{
+  "metadata": {
+    "guid": "new-plan-visibiliy-guid",
+    "url": "/v2/service_plan_visibilities/new-plan-visibiliy-guid",
+    "created_at": "2016-06-08T16:41:31Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "service_plan_guid": "foo",
+    "organization_guid": "bar",
+    "service_plan_url": "/v2/service_plans/foo",
+    "organization_url": "/v2/organizations/bar"
+  }
+}"""
+    fake_requests.post(
+        "http://localhost/v2/service_plan_visibilities", text=response_body
+    )
+    res = service_plan.enable_plan_for_org("foo", "bar", client)


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add cf client
- add fixtures for CF client

The testing here is done by mocking the `requests` library. I tried to avoid this, because it feels like it assumes too much knowledge about what cloudfoundry-client is doing, but I also tried mocking that library and things got out of hand quick, and required even more knowledge about the client, so I think this is better? maybe? 

Said differently:
This testing will break very hard if the library stops using `requests` but that is the _de facto_ library in python, and has been for years. The alternative is to mock out the library itself, which takes a ton more fixtures, and will probably break more frequently in smaller ways.

## Security considerations

None