### PR TITLE
Script to generate TXT records for domains that will need to be migrated

### DIFF
--- a/flagger/__main__.py
+++ b/flagger/__main__.py
@@ -1,0 +1,14 @@
+import sys
+from flagger import queries, aws
+
+
+def main():
+    dry_run = "--dry-run" in sys.argv
+    if dry_run:
+        print("Dry run: not making any actual changes")
+    for domain in queries.find_domains():
+        aws.create_semaphore(domain, dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/flagger/__main__.py
+++ b/flagger/__main__.py
@@ -3,10 +3,20 @@ from flagger import queries, aws
 
 
 def main():
-    dry_run = "--dry-run" in sys.argv
+    args = sys.argv
+    dry_run = False
+    while len(args) > 1:
+        arg = args.pop()
+        if arg == "--dry-run":
+            dry_run = True
+        else:
+            print(f"Unknown option: {arg}\nUsage: python3 -m flagger [--dry-run]")
+            exit(1)
     if dry_run:
         print("Dry run: not making any actual changes")
-    for domain in queries.find_domains():
+    domains = queries.find_domains()
+    print(f"{len(domains)} domain(s) found")
+    for domain in domains:
         aws.create_semaphore(domain, dry_run)
 
 

--- a/flagger/aws.py
+++ b/flagger/aws.py
@@ -1,0 +1,8 @@
+import boto3
+
+route53 = boto3.client("route53")
+
+def create_semaphore(domain, dry_run=False):
+    print(f"Creating TXT record for: {domain}")
+    if dry_run: return
+    # TODO: implement Route53 TXT record creation here

--- a/flagger/aws.py
+++ b/flagger/aws.py
@@ -1,8 +1,25 @@
-import boto3
+from migrator.extensions import route53, config
 
-route53 = boto3.client("route53")
 
 def create_semaphore(domain, dry_run=False):
-    print(f"Creating TXT record for: {domain}")
-    if dry_run: return
-    # TODO: implement Route53 TXT record creation here
+    resource_name = f"_acme-challenge.{domain}.{config.DNS_ROOT_DOMAIN}"
+    print(f"Creating semaphore TXT record '{config.SEMAPHORE}' for {resource_name}")
+    if dry_run:
+        return
+    route53.change_resource_record_sets(
+        HostedZoneId=config.ROUTE53_ZONE_ID,
+        ChangeBatch={
+            "Changes": [
+                {
+                    "Action": "UPSERT",
+                    "ResourceRecordSet": {
+                        "Name": resource_name,
+                        "Type": "TXT",
+                        "ResourceRecords": [
+                            {"Value": config.SEMAPHORE},
+                        ],
+                    },
+                },
+            ],
+        },
+    )

--- a/flagger/queries.py
+++ b/flagger/queries.py
@@ -1,0 +1,9 @@
+from migrator.db import session_handler
+from migrator.migration import find_active_instances
+
+# Extract a list of domain names from all CdnRoutes.
+def find_domains():
+    with session_handler() as session:
+        routes = find_active_instances(session)
+        domains = list(map(lambda route: route.domain_external, routes))
+        return domains

--- a/flagger/queries.py
+++ b/flagger/queries.py
@@ -5,5 +5,7 @@ from migrator.migration import find_active_instances
 def find_domains():
     with session_handler() as session:
         routes = find_active_instances(session)
-        domains = list(map(lambda route: route.domain_external, routes))
+        domains = []
+        for route in routes:
+            domains.extend(route.domain_external_list())
         return domains

--- a/migrator/config.py
+++ b/migrator/config.py
@@ -18,6 +18,7 @@ class Config:
         self.env_parser = Env()
         self.cf_env_parser = AppEnv()
         self.ENV = self.env_parser("ENV")
+        self.SEMAPHORE = "cloud-gov-migration-ready"
 
 
 class LocalConfig(Config):

--- a/migrator/models.py
+++ b/migrator/models.py
@@ -66,6 +66,9 @@ class CdnRoute(CdnBase):
     # provisioned
     state = sa.Column(sa.Text)
 
+    def domain_external_list(self):
+        return self.domain_external.split(",")
+
 
 class CdnCertificate(CdnBase):
     __tablename__ = "certificates"

--- a/tests/lib/fake_route53.py
+++ b/tests/lib/fake_route53.py
@@ -48,6 +48,33 @@ class FakeRoute53(FakeAWS):
         )
         return change_id
 
+    def expect_create_TXT_and_return_change_id(
+        self, domain, semaphore, target_hosted_zone_id="Z2FDTNDATAQYW2"
+    ) -> str:
+        change_id = f"{domain} ID"
+        self.stubber.add_response(
+            "change_resource_record_sets",
+            self._change_info(change_id, "PENDING"),
+            {
+                "ChangeBatch": {
+                    "Changes": [
+                        {
+                            "Action": "UPSERT",
+                            "ResourceRecordSet": {
+                                "Name": domain,
+                                "Type": "TXT",
+                                "ResourceRecords": [
+                                    {"Value": semaphore},
+                                ],
+                            },
+                        }
+                    ]
+                },
+                "HostedZoneId": "FAKEZONEID",
+            },
+        )
+        return change_id
+
     def expect_wait_for_change_insync(self, change_id: str):
         self.stubber.add_response(
             "get_change", self._change_info(change_id, "PENDING"), {"Id": change_id}

--- a/tests/unit/test_aws.py
+++ b/tests/unit/test_aws.py
@@ -1,0 +1,9 @@
+from flagger import aws
+
+
+def test_create_semaphore_txt_record(route53):
+    # No assertion needed in this test; fake route53 will throw an exception on failure
+    route53.expect_create_TXT_and_return_change_id(
+        "_acme-challenge.example.com.domains.cloud.test", "cloud-gov-migration-ready"
+    )
+    aws.create_semaphore("example.com")

--- a/tests/unit/test_cdn_db.py
+++ b/tests/unit/test_cdn_db.py
@@ -42,3 +42,31 @@ def test_check_connections():
     with pytest.raises(Exception):
         db.check_connections(cdn_session_maker=Session, external_domain_binding=engine)
     db.check_connections()
+
+
+def test_cdnroute_model_can_return_single_domain_in_domain_external_list(clean_db):
+    route = models.CdnRoute()
+    route.id = 12345
+    route.instance_id = "disposable-route-id"
+    route.state = "deprovisioned"
+    route.domain_external = "example.com"
+    clean_db.add(route)
+    clean_db.commit()
+
+    route = clean_db.query(models.CdnRoute).filter_by(id=12345).first()
+    assert route.domain_external_list() == ["example.com"]
+
+
+def test_cdnroute_model_can_return_multiple_domains_in_domain_external_list(clean_db):
+    route = models.CdnRoute()
+    route.id = 12345
+    route.instance_id = "disposable-route-id"
+    route.state = "deprovisioned"
+    route.domain_external = "example1.com,example2.com,example3.com"
+    clean_db.add(route)
+    clean_db.commit()
+
+    route = clean_db.query(models.CdnRoute).filter_by(id=12345).first()
+    assert sorted(route.domain_external_list()) == sorted(
+        ["example1.com", "example2.com", "example3.com"]
+    )

--- a/tests/unit/test_flagger.py
+++ b/tests/unit/test_flagger.py
@@ -16,3 +16,22 @@ def test_flagger_finds_domains(clean_db):
     domains = find_domains()
     assert re.match(r"domain\d.example.com", domains[0])
     assert len(domains) == 5
+
+
+def test_flagger_finds_multiple_domains_in_route(clean_db):
+    route1 = CdnRoute()
+    route1.state = "provisioned"
+    route1.instance_id = "12345"
+    route1.domain_external = "example1.com,example2.com,example3.com"
+    clean_db.add(route1)
+    route2 = CdnRoute()
+    route2.state = "provisioned"
+    route2.instance_id = "67890"
+    route2.domain_external = "example4.com"
+    clean_db.add(route2)
+    clean_db.commit()
+    clean_db.close()
+    domains = find_domains()
+    assert sorted(domains) == sorted(
+        ["example1.com", "example2.com", "example3.com", "example4.com"]
+    )

--- a/tests/unit/test_flagger.py
+++ b/tests/unit/test_flagger.py
@@ -1,0 +1,18 @@
+import pytest
+import re
+from flagger.queries import find_domains
+from migrator.models import CdnRoute
+
+
+def test_flagger_finds_domains(clean_db):
+    for i in range(5):
+        route = CdnRoute()
+        route.state = "provisioned"
+        route.instance_id = f"instance-{i}"
+        route.domain_external = f"domain{i}.example.com"
+        clean_db.add(route)
+    clean_db.commit()
+    clean_db.close()
+    domains = find_domains()
+    assert re.match(r"domain\d.example.com", domains[0])
+    assert len(domains) == 5


### PR DESCRIPTION
## Changes proposed in this pull request:

Addresses #58 

- [x] Get the list of instances from CdnRoute
- [x] Get the domain names for each CdnRoute instance
- [x] Create the TXT records in Route53 for each of those
- [x] The script should also provide a --dry-run option to show what it will do without making any actual changes

## Security considerations

- This script will be able to generate TXT records for domains within our Route53 configuration
- Only operators who have access to our AWS accounts will be able to run it
