### PR TITLE
Add support for disabling a service plan

### DIFF
--- a/migrator/cf.py
+++ b/migrator/cf.py
@@ -31,7 +31,3 @@ def get_space_id_for_service_instance_id(instance_id, client):
 def get_org_id_for_space_id(space_id, client):
     response = client.v3.spaces.get(space_id)
     return response["relationships"]["organization"]["data"]["guid"]
-
-def get_service_plan_visibility_id_for_org_id(org_id, client):
-    response = client.v3.organizations.get(org_id)
-    return response["relationships"][""]

--- a/migrator/cf.py
+++ b/migrator/cf.py
@@ -19,12 +19,12 @@ def enable_plan_for_org(plan_id, org_id, client):
 
 
 def get_service_plan_visibility_ids_for_org(plan_id, org_id, client):
-    response = client.v2.service_plan_visibilities.list(
+    service_plan_visibilities = client.v2.service_plan_visibilities.list(
         service_plan_guid=plan_id, organization_guid=org_id
     )
     return [
         service_plan_visibility["metadata"]["guid"]
-        for service_plan_visibility in response
+        for service_plan_visibility in service_plan_visibilities
     ]
 
 

--- a/migrator/cf.py
+++ b/migrator/cf.py
@@ -14,11 +14,13 @@ def get_cf_client(config):
 
 
 def enable_plan_for_org(plan_id, org_id, client):
-    return client.v2.service_plan_visibilities.create(plan_id, org_id)
+    response = client.v2.service_plan_visibilities.create(plan_id, org_id)
+    return response["metadata"]["guid"]
 
 
-def disable_plan_for_org(plan_id, org_id, client):
-    pass
+# Takes in service plan visibility GUID
+def disable_plan_for_org(spv_id, client):
+    return client.v2.service_plan_visibilities.remove(spv_id)
 
 
 def get_space_id_for_service_instance_id(instance_id, client):
@@ -29,3 +31,7 @@ def get_space_id_for_service_instance_id(instance_id, client):
 def get_org_id_for_space_id(space_id, client):
     response = client.v3.spaces.get(space_id)
     return response["relationships"]["organization"]["data"]["guid"]
+
+def get_service_plan_visibility_id_for_org_id(org_id, client):
+    response = client.v3.organizations.get(org_id)
+    return response["relationships"][""]

--- a/migrator/cf.py
+++ b/migrator/cf.py
@@ -18,9 +18,18 @@ def enable_plan_for_org(plan_id, org_id, client):
     return response["metadata"]["guid"]
 
 
-# Takes in service plan visibility GUID
-def disable_plan_for_org(spv_id, client):
-    return client.v2.service_plan_visibilities.remove(spv_id)
+def get_service_plan_visibility_ids_for_org(plan_id, org_id, client):
+    response = client.v2.service_plan_visibilities.list(
+        service_plan_guid=plan_id, organization_guid=org_id
+    )
+    return [
+        service_plan_visibility["metadata"]["guid"]
+        for service_plan_visibility in response
+    ]
+
+
+def disable_plan_for_org(service_plan_visibility_id, client):
+    return client.v2.service_plan_visibilities.remove(service_plan_visibility_id)
 
 
 def get_space_id_for_service_instance_id(instance_id, client):

--- a/migrator/migration.py
+++ b/migrator/migration.py
@@ -29,7 +29,6 @@ class Migration:
         self._external_domain_broker_service_instance = None
         self._space_id = None
         self._org_id = None
-        self._service_plan_visibility_ids = None
 
     @property
     def has_valid_dns(self):

--- a/migrator/migration.py
+++ b/migrator/migration.py
@@ -29,7 +29,7 @@ class Migration:
         self._external_domain_broker_service_instance = None
         self._space_id = None
         self._org_id = None
-        self._service_plan_visibility_id = None
+        self._service_plan_visibility_ids = None
 
     @property
     def has_valid_dns(self):
@@ -121,14 +121,18 @@ class Migration:
             self._org_id = cf.get_org_id_for_space_id(self.space_id, self.client)
         return self._org_id
 
-    def enable_migration_service_plan(self):
-        self._service_plan_visibility_id = cf.enable_plan_for_org(
+    @property
+    def service_plan_visibility_ids(self):
+        return cf.get_service_plan_visibility_ids_for_org(
             migration_plan_guid, self.org_id, self.client
         )
 
+    def enable_migration_service_plan(self):
+        cf.enable_plan_for_org(migration_plan_guid, self.org_id, self.client)
+
     def disable_migration_service_plan(self):
-        cf.disable_plan_for_org(self._service_plan_visibility_id, self.client)
-        self._service_plan_visibility_id = None
+        for service_plan_visibility_id in self.service_plan_visibility_ids:
+            cf.disable_plan_for_org(service_plan_visibility_id, self.client)
 
     def upsert_dns(self):
         change_ids = []

--- a/migrator/migration.py
+++ b/migrator/migration.py
@@ -29,6 +29,7 @@ class Migration:
         self._external_domain_broker_service_instance = None
         self._space_id = None
         self._org_id = None
+        self._service_plan_visibility_id = None
 
     @property
     def has_valid_dns(self):
@@ -121,7 +122,13 @@ class Migration:
         return self._org_id
 
     def enable_migration_service_plan(self):
-        cf.enable_plan_for_org(migration_plan_guid, self.org_id, self.client)
+        self._service_plan_visibility_id = cf.enable_plan_for_org(
+            migration_plan_guid, self.org_id, self.client
+        )
+
+    def disable_migration_service_plan(self):
+        cf.disable_plan_for_org(self._service_plan_visibility_id, self.client)
+        self._service_plan_visibility_id = None
 
     def upsert_dns(self):
         change_ids = []

--- a/tests/unit/test_cf.py
+++ b/tests/unit/test_cf.py
@@ -47,6 +47,14 @@ def test_enable_service_plan_2(fake_requests, fake_cf_client):
     )
     res = cf.enable_plan_for_org("foo", "bar", fake_cf_client)
 
+def test_disable_service_plan_2(fake_requests, fake_cf_client):
+    response_body = ""
+    fake_requests.delete(
+        "http://localhost/v2/service_plan_visibilities/new-plan-visibiliy-guid",
+        text=response_body
+    )
+    res = cf.disable_plan_for_org("new-plan-visibiliy-guid", fake_cf_client)
+
 
 def test_get_space_for_instance(migration, fake_requests, fake_cf_client):
     response_body = """

--- a/tests/unit/test_cf.py
+++ b/tests/unit/test_cf.py
@@ -47,11 +47,12 @@ def test_enable_service_plan_2(fake_requests, fake_cf_client):
     )
     res = cf.enable_plan_for_org("foo", "bar", fake_cf_client)
 
+
 def test_disable_service_plan_2(fake_requests, fake_cf_client):
     response_body = ""
     fake_requests.delete(
         "http://localhost/v2/service_plan_visibilities/new-plan-visibiliy-guid",
-        text=response_body
+        text=response_body,
     )
     res = cf.disable_plan_for_org("new-plan-visibiliy-guid", fake_cf_client)
 

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -343,16 +343,47 @@ def test_migration_disables_plan_in_org(clean_db, fake_cf_client, fake_requests)
     migration = Migration(route, clean_db, fake_cf_client)
     migration._space_id = "my-space-guid"
     migration._org_id = "my-org-guid"
-    migration._service_plan_visibility_id = "my-service-plan-visibility"
 
-    response_body = ""
+    response_body_get = """
+{
+   "total_results": 1,
+   "total_pages": 1,
+   "prev_url": null,
+   "next_url": null,
+   "resources": [
+      {
+         "metadata": {
+            "guid": "my-service-plan-visibility",
+            "url": "/v2/service_plan_visibilities/my-service-plan-visibility",
+            "created_at": "2021-02-22T21:15:57Z",
+            "updated_at": "2021-02-22T21:15:57Z"
+         },
+         "entity": {
+            "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
+            "organization_guid": "my-org-guid",
+            "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
+            "organization_url": "/v2/organizations/my-org-guid"
+         }
+      }
+   ]
+}
+    """
+    fake_requests.get(
+        "http://localhost/v2/service_plan_visibilities?q=organization_guid:my-org-guid&q=service_plan_guid:739e78F5-a919-46ef-9193-1293cc086c17",
+        text=response_body_get,
+    )
+
+    response_body_delete = ""
     fake_requests.delete(
         "http://localhost/v2/service_plan_visibilities/my-service-plan-visibility",
-        text=response_body
+        text=response_body_delete,
     )
 
     migration.disable_migration_service_plan()
 
     assert fake_requests.called
     last_request = fake_requests.request_history[-1]
-    assert last_request.url == "http://localhost/v2/service_plan_visibilities/my-service-plan-visibility"
+    assert (
+        last_request.url
+        == "http://localhost/v2/service_plan_visibilities/my-service-plan-visibility"
+    )

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -332,3 +332,27 @@ def test_migration_enables_plan_in_org(clean_db, fake_cf_client, fake_requests):
     assert fake_requests.called
     last_request = fake_requests.request_history[-1]
     assert last_request.url == "http://localhost/v2/service_plan_visibilities"
+
+
+def test_migration_disables_plan_in_org(clean_db, fake_cf_client, fake_requests):
+    route = CdnRoute()
+    route.state = "provisioned"
+    route.instance_id = "asdf-asdf"
+    route.domain_external = "example.com,foo.example.com"
+    route.dist_id = "some-distribution-id"
+    migration = Migration(route, clean_db, fake_cf_client)
+    migration._space_id = "my-space-guid"
+    migration._org_id = "my-org-guid"
+    migration._service_plan_visibility_id = "my-service-plan-visibility"
+
+    response_body = ""
+    fake_requests.delete(
+        "http://localhost/v2/service_plan_visibilities/my-service-plan-visibility",
+        text=response_body
+    )
+
+    migration.disable_migration_service_plan()
+
+    assert fake_requests.called
+    last_request = fake_requests.request_history[-1]
+    assert last_request.url == "http://localhost/v2/service_plan_visibilities/my-service-plan-visibility"


### PR DESCRIPTION
This changeset adds support to disable an existing service plan.  When a service plan is created, it is associated to an organization and represented via a unique object, a service plan visibility.  When disabling a plan, you remove this object via its own GUID.

## Changes proposed in this pull request:
- Adds functionality for disabling a service plan
- Tests for new functionality

## Security considerations:
- None