### PR TITLE
Add support to instantiate a migrator service in each space of an org

### DIFF
--- a/flagger/aws.py
+++ b/flagger/aws.py
@@ -15,9 +15,7 @@ def create_semaphore(domain, dry_run=False):
                     "ResourceRecordSet": {
                         "Name": resource_name,
                         "Type": "TXT",
-                        "ResourceRecords": [
-                            {"Value": config.SEMAPHORE},
-                        ],
+                        "ResourceRecords": [{"Value": config.SEMAPHORE},],
                     },
                 },
             ],

--- a/migrator/cf.py
+++ b/migrator/cf.py
@@ -43,11 +43,7 @@ def get_org_id_for_space_id(space_id, client):
 
 
 def get_all_space_ids_for_org(org_id, client):
-    spaces = client.v3.spaces.list(
-        organization_guids=[
-            org_id,
-        ]
-    )
+    spaces = client.v3.spaces.list(organization_guids=[org_id,])
     return [space["guid"] for space in spaces]
 
 

--- a/migrator/cf.py
+++ b/migrator/cf.py
@@ -54,4 +54,13 @@ def get_all_space_ids_for_org(org_id, client):
 def create_bare_migrator_service_instance_in_space(
     space_id, plan_id, instance_name, client
 ):
-    return client.v2.service_instances.create(space_id, plan_id, instance_name)
+    response = client.v2.service_instances.create(space_id, plan_id, instance_name)
+    return {
+        "guid": response["metadata"]["guid"],
+        "state": response["entity"]["last_operation"]["state"],
+    }
+
+
+def get_migrator_service_instance_status(instance_id, client):
+    response = client.v2.service_instances.get(instance_id)
+    return response["entity"]["last_operation"]["state"]

--- a/migrator/cf.py
+++ b/migrator/cf.py
@@ -40,3 +40,18 @@ def get_space_id_for_service_instance_id(instance_id, client):
 def get_org_id_for_space_id(space_id, client):
     response = client.v3.spaces.get(space_id)
     return response["relationships"]["organization"]["data"]["guid"]
+
+
+def get_all_space_ids_for_org(org_id, client):
+    spaces = client.v3.spaces.list(
+        organization_guids=[
+            org_id,
+        ]
+    )
+    return [space["guid"] for space in spaces]
+
+
+def create_bare_migrator_service_instance_in_space(
+    space_id, plan_id, instance_name, client
+):
+    return client.v2.service_instances.create(space_id, plan_id, instance_name)

--- a/migrator/config.py
+++ b/migrator/config.py
@@ -40,6 +40,8 @@ class LocalConfig(Config):
         self.CF_USERNAME = "fake-username"
         self.CF_PASSWORD = "fake-password"
         self.CF_API_ENDPOINT = "http://localhost"
+        self.SERVICE_CHANGE_RETRY_COUNT = 2
+        self.SERVICE_CHANGE_POLL_TIME_SECONDS = 0.01
 
 
 class AppConfig(Config):
@@ -65,6 +67,8 @@ class AppConfig(Config):
         self.CF_API_ENDPOINT = self.env_parser("CF_API_ENDPOINT")
         self.AWS_POLL_WAIT_TIME_IN_SECONDS = 60
         self.AWS_POLL_MAX_ATTEMPTS = 10
+        self.SERVICE_CHANGE_RETRY_COUNT = 60
+        self.SERVICE_CHANGE_POLL_TIME_SECONDS = 10
 
 
 class DevelopmentConfig(AppConfig):

--- a/migrator/extensions.py
+++ b/migrator/extensions.py
@@ -18,3 +18,5 @@ route53 = commercial_session.client("route53")
 
 migration_plan_guid = "739e78F5-a919-46ef-9193-1293cc086c17"
 migration_plan_instance_name = "external-domain-broker-migrator"
+
+migration_instance_check_timeout = 600  # in seconds

--- a/migrator/extensions.py
+++ b/migrator/extensions.py
@@ -17,3 +17,4 @@ iam_commercial = commercial_session.client("iam")
 route53 = commercial_session.client("route53")
 
 migration_plan_guid = "739e78F5-a919-46ef-9193-1293cc086c17"
+migration_plan_instance_name = "external-domain-broker-migrator"

--- a/migrator/extensions.py
+++ b/migrator/extensions.py
@@ -18,5 +18,3 @@ route53 = commercial_session.client("route53")
 
 migration_plan_guid = "739e78F5-a919-46ef-9193-1293cc086c17"
 migration_plan_instance_name = "external-domain-broker-migrator"
-
-migration_instance_check_timeout = 600  # in seconds

--- a/migrator/migration.py
+++ b/migrator/migration.py
@@ -135,13 +135,12 @@ class Migration:
             cf.disable_plan_for_org(service_plan_visibility_id, self.client)
 
     def create_bare_migrator_instance_in_org_spaces(self):
-        for space_id in cf.get_all_space_ids_for_org(self.org_id, self.client):
-            cf.create_bare_migrator_service_instance_in_space(
-                self.space_id,
-                migration_plan_guid,
-                migration_plan_instance_name,
-                self.client,
-            )
+        cf.create_bare_migrator_service_instance_in_space(
+            self.space_id,
+            migration_plan_guid,
+            migration_plan_instance_name,
+            self.client,
+        )
 
     def upsert_dns(self):
         change_ids = []

--- a/migrator/migration.py
+++ b/migrator/migration.py
@@ -7,6 +7,7 @@ from migrator.extensions import (
     iam_commercial,
     route53,
     migration_plan_guid,
+    migration_plan_instance_name,
 )
 from migrator.models import CdnRoute
 
@@ -132,6 +133,15 @@ class Migration:
     def disable_migration_service_plan(self):
         for service_plan_visibility_id in self.service_plan_visibility_ids:
             cf.disable_plan_for_org(service_plan_visibility_id, self.client)
+
+    def create_bare_migrator_instance_in_org_spaces(self):
+        for space_id in cf.get_all_space_ids_for_org(self.org_id, self.client):
+            cf.create_bare_migrator_service_instance_in_space(
+                self.space_id,
+                migration_plan_guid,
+                migration_plan_instance_name,
+                self.client,
+            )
 
     def upsert_dns(self):
         change_ids = []

--- a/migrator/migration.py
+++ b/migrator/migration.py
@@ -134,7 +134,7 @@ class Migration:
         for service_plan_visibility_id in self.service_plan_visibility_ids:
             cf.disable_plan_for_org(service_plan_visibility_id, self.client)
 
-    def create_bare_migrator_instance_in_org_spaces(self):
+    def create_bare_migrator_instance_in_org_space(self):
         cf.create_bare_migrator_service_instance_in_space(
             self.space_id,
             migration_plan_guid,

--- a/tests/lib/fake_route53.py
+++ b/tests/lib/fake_route53.py
@@ -63,9 +63,7 @@ class FakeRoute53(FakeAWS):
                             "ResourceRecordSet": {
                                 "Name": domain,
                                 "Type": "TXT",
-                                "ResourceRecords": [
-                                    {"Value": semaphore},
-                                ],
+                                "ResourceRecords": [{"Value": semaphore},],
                             },
                         }
                     ]

--- a/tests/unit/test_cf.py
+++ b/tests/unit/test_cf.py
@@ -247,3 +247,100 @@ def test_get_all_space_ids_for_org_3(fake_cf_client, fake_requests):
         "my-space-1-guid",
         "my-space-2-guid",
     ]
+
+
+def test_create_bare_migrator_service_instance_in_space(fake_cf_client, fake_requests):
+    response_body = """
+{
+  "metadata": {
+    "guid": "my-migrator-instance",
+    "url": "/v2/service_instances/my-migrator-instance",
+    "created_at": "2016-06-08T16:41:29Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "external-domain-broker-migrator",
+    "credentials": {
+
+    },
+    "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
+    "space_guid": "my-space-guid",
+    "gateway_data": null,
+    "dashboard_url": null,
+    "type": "managed_service_instance",
+    "last_operation": {
+      "type": "create",
+      "state": "in progress",
+      "description": "",
+      "updated_at": "2016-06-08T16:41:26Z",
+      "created_at": "2016-06-08T16:41:29Z"
+    },
+    "space_url": "/v2/spaces/my-space-1-guid",
+    "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
+    "service_bindings_url": "/v2/service_instances/my-migrator-instance/service_bindings",
+    "service_keys_url": "/v2/service_instances/my-migrator-instance/service_keys",
+    "routes_url": "/v2/service_instances/my-migrator-instance/routes",
+    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+    "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
+  }
+}
+    """
+
+    fake_requests.post("http://localhost/v2/service_instances", text=response_body)
+
+    response = cf.create_bare_migrator_service_instance_in_space(
+        "my-space-guid",
+        "739e78F5-a919-46ef-9193-1293cc086c17",
+        "external-domain-broker-migrator",
+        fake_cf_client,
+    )
+
+    assert response["guid"] == "my-migrator-instance"
+    assert response["state"] == "in progress"
+
+
+def test_get_migrator_service_instance_status(fake_cf_client, fake_requests):
+    response_body = """
+{
+  "metadata": {
+    "guid": "my-migrator-instance",
+    "url": "/v2/service_instances/my-migrator-instance",
+    "created_at": "2016-06-08T16:41:29Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "external-domain-broker-migrator",
+    "credentials": {
+
+    },
+    "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
+    "space_guid": "my-space-guid",
+    "gateway_data": null,
+    "dashboard_url": null,
+    "type": "managed_service_instance",
+    "last_operation": {
+      "type": "create",
+      "state": "succeeded",
+      "description": "",
+      "updated_at": "2016-06-08T16:41:26Z",
+      "created_at": "2016-06-08T16:41:29Z"
+    },
+    "space_url": "/v2/spaces/my-space-guid",
+    "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
+    "service_bindings_url": "/v2/service_instances/my-migrator-instance/service_bindings",
+    "service_keys_url": "/v2/service_instances/my-migrator-instance/service_keys",
+    "routes_url": "/v2/service_instances/my-migrator-instance/routes",
+    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+    "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
+  }
+}
+    """
+
+    fake_requests.get(
+        "http://localhost/v2/service_instances/my-migrator-instance", text=response_body
+    )
+
+    assert (
+        cf.get_migrator_service_instance_status("my-migrator-instance", fake_cf_client)
+        == "succeeded"
+    )

--- a/tests/unit/test_cf.py
+++ b/tests/unit/test_cf.py
@@ -148,3 +148,102 @@ def test_get_org_id_for_space_id(fake_cf_client, fake_requests):
 """
     fake_requests.get("http://localhost/v3/spaces/my-space-guid", text=response_body)
     assert cf.get_org_id_for_space_id("my-space-guid", fake_cf_client) == "my-org-guid"
+
+
+def test_get_all_space_ids_for_org_3(fake_cf_client, fake_requests):
+    response_body = """
+{
+   "pagination": {
+      "total_results": 2,
+      "total_pages": 1,
+      "first": {
+         "href": "https://api.fr.cloud.gov/v3/spaces?organization_guids=my-org-guid&page=1&per_page=50"
+      },
+      "last": {
+         "href": "https://api.fr.cloud.gov/v3/spaces?organization_guids=my-org-guid&page=1&per_page=50"
+      },
+      "next": null,
+      "previous": null
+   },
+   "resources": [
+     {
+         "guid": "my-space-1-guid",
+         "created_at": "2021-01-27T20:52:07Z",
+         "updated_at": "2021-01-27T20:52:07Z",
+         "name": "space-1",
+         "relationships": {
+            "organization": {
+               "data": {
+                  "guid": "my-org-guid"
+               }
+            },
+            "quota": {
+               "data": null
+            }
+         },
+         "metadata": {
+            "labels": {},
+            "annotations": {}
+         },
+         "links": {
+            "self": {
+               "href": "https://api.fr.cloud.gov/v3/spaces/my-space-1-guid"
+            },
+            "organization": {
+               "href": "https://api.fr.cloud.gov/v3/organizations/my-org-guid"
+            },
+            "features": {
+               "href": "https://api.fr.cloud.gov/v3/spaces/my-space-1-guid/features"
+            },
+            "apply_manifest": {
+               "href": "https://api.fr.cloud.gov/v3/spaces/my-space-1-guid/actions/apply_manifest",
+               "method": "POST"
+            }
+         }
+      },
+      {
+         "guid": "my-space-2-guid",
+         "created_at": "2021-02-04T16:26:06Z",
+         "updated_at": "2021-02-04T16:26:06Z",
+         "name": "space-2",
+         "relationships": {
+            "organization": {
+               "data": {
+                  "guid": "my-org-guid"
+               }
+            },
+            "quota": {
+               "data": null
+            }
+         },
+         "metadata": {
+            "labels": {},
+            "annotations": {}
+         },
+         "links": {
+            "self": {
+               "href": "https://api.fr.cloud.gov/v3/spaces/my-space-2-guid"
+            },
+            "organization": {
+               "href": "https://api.fr.cloud.gov/v3/organizations/my-org-guid"
+            },
+            "features": {
+               "href": "https://api.fr.cloud.gov/v3/spaces/my-space-2-guid/features"
+            },
+            "apply_manifest": {
+               "href": "https://api.fr.cloud.gov/v3/spaces/my-space-2-guid/actions/apply_manifest",
+               "method": "POST"
+            }
+         }
+      }
+   ]
+}
+    """
+
+    fake_requests.get(
+        "http://localhost/v3/spaces?organization_guids=my-org-guid", text=response_body
+    )
+    assert cf.get_all_space_ids_for_org("my-org-guid", fake_cf_client) == [
+        "my-space-1-guid",
+        "my-space-2-guid",
+    ]

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -389,7 +389,7 @@ def test_migration_disables_plan_in_org(clean_db, fake_cf_client, fake_requests)
     )
 
 
-def test_create_bare_migrator_instance_in_org_space(
+def test_create_bare_migrator_instance_in_org_space_success(
     clean_db, fake_cf_client, fake_requests
 ):
     route = CdnRoute()
@@ -426,7 +426,7 @@ def test_create_bare_migrator_instance_in_org_space(
       "updated_at": "2016-06-08T16:41:26Z",
       "created_at": "2016-06-08T16:41:29Z"
     },
-    "space_url": "/v2/spaces/my-space-1-guid",
+    "space_url": "/v2/spaces/my-space-guid",
     "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
     "service_bindings_url": "/v2/service_instances/my-migrator-instance/service_bindings",
     "service_keys_url": "/v2/service_instances/my-migrator-instance/service_keys",
@@ -440,8 +440,255 @@ def test_create_bare_migrator_instance_in_org_space(
         "http://localhost/v2/service_instances", text=response_body_create_instance
     )
 
+    response_body_check_instance = """
+{
+  "metadata": {
+    "guid": "my-migrator-instance",
+    "url": "/v2/service_instances/my-migrator-instance",
+    "created_at": "2016-06-08T16:41:29Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "external-domain-broker-migrator",
+    "credentials": {
+
+    },
+    "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
+    "space_guid": "my-space-guid",
+    "gateway_data": null,
+    "dashboard_url": null,
+    "type": "managed_service_instance",
+    "last_operation": {
+      "type": "create",
+      "state": "succeeded",
+      "description": "",
+      "updated_at": "2016-06-08T16:41:26Z",
+      "created_at": "2016-06-08T16:41:29Z"
+    },
+    "space_url": "/v2/spaces/my-space-guid",
+    "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
+    "service_bindings_url": "/v2/service_instances/my-migrator-instance/service_bindings",
+    "service_keys_url": "/v2/service_instances/my-migrator-instance/service_keys",
+    "routes_url": "/v2/service_instances/my-migrator-instance/routes",
+    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+    "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
+  }
+}
+    """
+
+    fake_requests.get(
+        "http://localhost/v2/service_instances/my-migrator-instance",
+        text=response_body_check_instance,
+    )
+
     migration.create_bare_migrator_instance_in_org_space()
 
     assert fake_requests.called
     last_request = fake_requests.request_history[-1]
-    assert last_request.url == "http://localhost/v2/service_instances"
+    assert (
+        last_request.url == "http://localhost/v2/service_instances/my-migrator-instance"
+    )
+
+
+def test_create_bare_migrator_instance_in_org_space_failure(
+    clean_db, fake_cf_client, fake_requests
+):
+    route = CdnRoute()
+    route.state = "provisioned"
+    route.instance_id = "asdf-asdf"
+    route.domain_external = "example.com,foo.example.com"
+    route.dist_id = "some-distribution-id"
+    migration = Migration(route, clean_db, fake_cf_client)
+    migration._space_id = "my-space-guid"
+    migration._org_id = "my-org-guid"
+
+    response_body_create_instance = """
+{
+  "metadata": {
+    "guid": "my-migrator-instance",
+    "url": "/v2/service_instances/my-migrator-instance",
+    "created_at": "2016-06-08T16:41:29Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "external-domain-broker-migrator",
+    "credentials": {
+
+    },
+    "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
+    "space_guid": "my-space-guid",
+    "gateway_data": null,
+    "dashboard_url": null,
+    "type": "managed_service_instance",
+    "last_operation": {
+      "type": "create",
+      "state": "in progress",
+      "description": "",
+      "updated_at": "2016-06-08T16:41:26Z",
+      "created_at": "2016-06-08T16:41:29Z"
+    },
+    "space_url": "/v2/spaces/my-space-guid",
+    "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
+    "service_bindings_url": "/v2/service_instances/my-migrator-instance/service_bindings",
+    "service_keys_url": "/v2/service_instances/my-migrator-instance/service_keys",
+    "routes_url": "/v2/service_instances/my-migrator-instance/routes",
+    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+    "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
+  }
+}
+    """
+    fake_requests.post(
+        "http://localhost/v2/service_instances", text=response_body_create_instance
+    )
+
+    response_body_check_instance = """
+{
+  "metadata": {
+    "guid": "my-migrator-instance",
+    "url": "/v2/service_instances/my-migrator-instance",
+    "created_at": "2016-06-08T16:41:29Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "external-domain-broker-migrator",
+    "credentials": {
+
+    },
+    "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
+    "space_guid": "my-space-guid",
+    "gateway_data": null,
+    "dashboard_url": null,
+    "type": "managed_service_instance",
+    "last_operation": {
+      "type": "create",
+      "state": "failed",
+      "description": "",
+      "updated_at": "2016-06-08T16:41:26Z",
+      "created_at": "2016-06-08T16:41:29Z"
+    },
+    "space_url": "/v2/spaces/my-space-guid",
+    "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
+    "service_bindings_url": "/v2/service_instances/my-migrator-instance/service_bindings",
+    "service_keys_url": "/v2/service_instances/my-migrator-instance/service_keys",
+    "routes_url": "/v2/service_instances/my-migrator-instance/routes",
+    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+    "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
+  }
+}
+    """
+
+    fake_requests.get(
+        "http://localhost/v2/service_instances/my-migrator-instance",
+        text=response_body_check_instance,
+    )
+
+    with pytest.raises(Exception):
+        migration.create_bare_migrator_instance_in_org_space()
+
+    assert fake_requests.called
+    last_request = fake_requests.request_history[-1]
+    assert (
+        last_request.url == "http://localhost/v2/service_instances/my-migrator-instance"
+    )
+
+
+def test_create_bare_migrator_instance_in_org_space_timeout_failure(
+    clean_db, fake_cf_client, fake_requests
+):
+    route = CdnRoute()
+    route.state = "provisioned"
+    route.instance_id = "asdf-asdf"
+    route.domain_external = "example.com,foo.example.com"
+    route.dist_id = "some-distribution-id"
+    migration = Migration(route, clean_db, fake_cf_client)
+    migration._space_id = "my-space-guid"
+    migration._org_id = "my-org-guid"
+
+    response_body_create_instance = """
+{
+  "metadata": {
+    "guid": "my-migrator-instance",
+    "url": "/v2/service_instances/my-migrator-instance",
+    "created_at": "2016-06-08T16:41:29Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "external-domain-broker-migrator",
+    "credentials": {
+
+    },
+    "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
+    "space_guid": "my-space-guid",
+    "gateway_data": null,
+    "dashboard_url": null,
+    "type": "managed_service_instance",
+    "last_operation": {
+      "type": "create",
+      "state": "in progress",
+      "description": "",
+      "updated_at": "2016-06-08T16:41:26Z",
+      "created_at": "2016-06-08T16:41:29Z"
+    },
+    "space_url": "/v2/spaces/my-space-guid",
+    "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
+    "service_bindings_url": "/v2/service_instances/my-migrator-instance/service_bindings",
+    "service_keys_url": "/v2/service_instances/my-migrator-instance/service_keys",
+    "routes_url": "/v2/service_instances/my-migrator-instance/routes",
+    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+    "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
+  }
+}
+    """
+    fake_requests.post(
+        "http://localhost/v2/service_instances", text=response_body_create_instance
+    )
+
+    response_body_check_instance = """
+{
+  "metadata": {
+    "guid": "my-migrator-instance",
+    "url": "/v2/service_instances/my-migrator-instance",
+    "created_at": "2016-06-08T16:41:29Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "external-domain-broker-migrator",
+    "credentials": {
+
+    },
+    "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
+    "space_guid": "my-space-guid",
+    "gateway_data": null,
+    "dashboard_url": null,
+    "type": "managed_service_instance",
+    "last_operation": {
+      "type": "create",
+      "state": "in progress",
+      "description": "",
+      "updated_at": "2016-06-08T16:41:26Z",
+      "created_at": "2016-06-08T16:41:29Z"
+    },
+    "space_url": "/v2/spaces/my-space-guid",
+    "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
+    "service_bindings_url": "/v2/service_instances/my-migrator-instance/service_bindings",
+    "service_keys_url": "/v2/service_instances/my-migrator-instance/service_keys",
+    "routes_url": "/v2/service_instances/my-migrator-instance/routes",
+    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+    "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
+  }
+}
+    """
+
+    fake_requests.get(
+        "http://localhost/v2/service_instances/my-migrator-instance",
+        text=response_body_check_instance,
+    )
+
+    with pytest.raises(Exception):
+        migration.create_bare_migrator_instance_in_org_space(timeout=1)
+
+    assert fake_requests.called
+    last_request = fake_requests.request_history[-1]
+    assert (
+        last_request.url == "http://localhost/v2/service_instances/my-migrator-instance"
+    )

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -685,10 +685,12 @@ def test_create_bare_migrator_instance_in_org_space_timeout_failure(
     )
 
     with pytest.raises(Exception):
-        migration.create_bare_migrator_instance_in_org_space(timeout=1)
+        migration.create_bare_migrator_instance_in_org_space()
 
-    assert fake_requests.called
     last_request = fake_requests.request_history[-1]
     assert (
         last_request.url == "http://localhost/v2/service_instances/my-migrator-instance"
     )
+
+    # one for the post, 2 for the status checks
+    assert len(fake_requests.request_history) == 3

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -401,100 +401,6 @@ def test_create_bare_migrator_instance_in_org_spaces(
     migration._space_id = "my-space-guid"
     migration._org_id = "my-org-guid"
 
-    response_body_get_spaces = """
-{
-   "pagination": {
-      "total_results": 2,
-      "total_pages": 1,
-      "first": {
-         "href": "https://api.fr.cloud.gov/v3/spaces?organization_guids=my-org-guid&page=1&per_page=50"
-      },
-      "last": {
-         "href": "https://api.fr.cloud.gov/v3/spaces?organization_guids=my-org-guid&page=1&per_page=50"
-      },
-      "next": null,
-      "previous": null
-   },
-   "resources": [
-     {
-         "guid": "my-space-1-guid",
-         "created_at": "2021-01-27T20:52:07Z",
-         "updated_at": "2021-01-27T20:52:07Z",
-         "name": "space-1",
-         "relationships": {
-            "organization": {
-               "data": {
-                  "guid": "my-org-guid"
-               }
-            },
-            "quota": {
-               "data": null
-            }
-         },
-         "metadata": {
-            "labels": {},
-            "annotations": {}
-         },
-         "links": {
-            "self": {
-               "href": "https://api.fr.cloud.gov/v3/spaces/my-space-1-guid"
-            },
-            "organization": {
-               "href": "https://api.fr.cloud.gov/v3/organizations/my-org-guid"
-            },
-            "features": {
-               "href": "https://api.fr.cloud.gov/v3/spaces/my-space-1-guid/features"
-            },
-            "apply_manifest": {
-               "href": "https://api.fr.cloud.gov/v3/spaces/my-space-1-guid/actions/apply_manifest",
-               "method": "POST"
-            }
-         }
-      },
-      {
-         "guid": "my-space-2-guid",
-         "created_at": "2021-02-04T16:26:06Z",
-         "updated_at": "2021-02-04T16:26:06Z",
-         "name": "space-2",
-         "relationships": {
-            "organization": {
-               "data": {
-                  "guid": "my-org-guid"
-               }
-            },
-            "quota": {
-               "data": null
-            }
-         },
-         "metadata": {
-            "labels": {},
-            "annotations": {}
-         },
-         "links": {
-            "self": {
-               "href": "https://api.fr.cloud.gov/v3/spaces/my-space-2-guid"
-            },
-            "organization": {
-               "href": "https://api.fr.cloud.gov/v3/organizations/my-org-guid"
-            },
-            "features": {
-               "href": "https://api.fr.cloud.gov/v3/spaces/my-space-2-guid/features"
-            },
-            "apply_manifest": {
-               "href": "https://api.fr.cloud.gov/v3/spaces/my-space-2-guid/actions/apply_manifest",
-               "method": "POST"
-            }
-         }
-      }
-   ]
-}
-    """
-
-    fake_requests.get(
-        "http://localhost/v3/spaces?organization_guids=my-org-guid",
-        text=response_body_get_spaces,
-    )
-
     response_body_create_instance = """
 {
   "metadata": {
@@ -509,7 +415,7 @@ def test_create_bare_migrator_instance_in_org_spaces(
 
     },
     "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
-    "space_guid": "my-space-1-guid",
+    "space_guid": "my-space-guid",
     "gateway_data": null,
     "dashboard_url": null,
     "type": "managed_service_instance",
@@ -537,7 +443,5 @@ def test_create_bare_migrator_instance_in_org_spaces(
     migration.create_bare_migrator_instance_in_org_spaces()
 
     assert fake_requests.called
-    second_last_request = fake_requests.request_history[-2]
     last_request = fake_requests.request_history[-1]
-    assert second_last_request.url == "http://localhost/v2/service_instances"
     assert last_request.url == "http://localhost/v2/service_instances"

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -389,7 +389,7 @@ def test_migration_disables_plan_in_org(clean_db, fake_cf_client, fake_requests)
     )
 
 
-def test_create_bare_migrator_instance_in_org_spaces(
+def test_create_bare_migrator_instance_in_org_space(
     clean_db, fake_cf_client, fake_requests
 ):
     route = CdnRoute()
@@ -440,7 +440,7 @@ def test_create_bare_migrator_instance_in_org_spaces(
         "http://localhost/v2/service_instances", text=response_body_create_instance
     )
 
-    migration.create_bare_migrator_instance_in_org_spaces()
+    migration.create_bare_migrator_instance_in_org_space()
 
     assert fake_requests.called
     last_request = fake_requests.request_history[-1]


### PR DESCRIPTION
This changeset adds support for instantiating a migrator service in each space found within an org.  This is needed once a customer is ready to perform a migration to the external domain broker.

## Changes proposed in this pull request:
- Adds ability to retrieve all spaces in an org
- Adds support for instantiating a migrator service in all spaces within an org
- Adds tests for the new functionality

## Security considerations:
- None; just adds support for creating a new service programmatically