### PR TITLE
Dns preload

### DIFF
--- a/flagger/__main__.py
+++ b/flagger/__main__.py
@@ -18,6 +18,9 @@ def main():
     print(f"{len(domains)} domain(s) found")
     for domain in domains:
         aws.create_semaphore(domain, dry_run)
+    domain_cdns = queries.find_aliases()
+    for domain_cdn in domain_cdns():
+        aws.create_cdn_alias(*domain_cdn)
 
 
 if __name__ == "__main__":

--- a/flagger/aws.py
+++ b/flagger/aws.py
@@ -21,3 +21,40 @@ def create_semaphore(domain, dry_run=False):
             ]
         },
     )
+
+
+def create_cdn_alias(internal_domain, cloudfront_domain):
+    print(f"Creating ALIAS '{internal_domain}' => {cloudfront_domain}")
+    if dry_run:
+        return
+    route53_response = route53.change_resource_record_sets(
+        ChangeBatch={
+            "Changes": [
+                {
+                    "Action": "UPSERT",
+                    "ResourceRecordSet": {
+                        "Type": "A",
+                        "Name": internal_domain,
+                        "AliasTarget": {
+                            "DNSName": cloudfront_domain,
+                            "HostedZoneId": config.CLOUDFRONT_HOSTED_ZONE_ID,
+                            "EvaluateTargetHealth": False,
+                        },
+                    },
+                },
+                {
+                    "Action": "UPSERT",
+                    "ResourceRecordSet": {
+                        "Type": "AAAA",
+                        "Name": internal_domain,
+                        "AliasTarget": {
+                            "DNSName": cloudfront_domain,
+                            "HostedZoneId": config.CLOUDFRONT_HOSTED_ZONE_ID,
+                            "EvaluateTargetHealth": False,
+                        },
+                    },
+                },
+            ]
+        },
+        HostedZoneId=config.ROUTE53_ZONE_ID,
+    )

--- a/flagger/aws.py
+++ b/flagger/aws.py
@@ -27,6 +27,7 @@ def create_cdn_alias(internal_domain, cloudfront_domain):
     print(f"Creating ALIAS '{internal_domain}' => {cloudfront_domain}")
     if dry_run:
         return
+    alias_record = f"{internal_domain}.{config.DNS_ROOT_DOMAIN}"
     route53_response = route53.change_resource_record_sets(
         ChangeBatch={
             "Changes": [
@@ -34,7 +35,7 @@ def create_cdn_alias(internal_domain, cloudfront_domain):
                     "Action": "UPSERT",
                     "ResourceRecordSet": {
                         "Type": "A",
-                        "Name": internal_domain,
+                        "Name": alias_record,
                         "AliasTarget": {
                             "DNSName": cloudfront_domain,
                             "HostedZoneId": config.CLOUDFRONT_HOSTED_ZONE_ID,
@@ -46,7 +47,7 @@ def create_cdn_alias(internal_domain, cloudfront_domain):
                     "Action": "UPSERT",
                     "ResourceRecordSet": {
                         "Type": "AAAA",
-                        "Name": internal_domain,
+                        "Name": alias_record,
                         "AliasTarget": {
                             "DNSName": cloudfront_domain,
                             "HostedZoneId": config.CLOUDFRONT_HOSTED_ZONE_ID,

--- a/flagger/queries.py
+++ b/flagger/queries.py
@@ -9,3 +9,12 @@ def find_domains():
         for route in routes:
             domains.extend(route.domain_external_list())
         return domains
+
+
+def find_aliases():
+    with session_handler() as session:
+        routes = find_active_instances(session)
+        domain_cdns = []
+        for route in routes:
+            for domain in route.domain_external_list():
+                domain_cdns.append((domain, route.domain_internal))

--- a/flagger/queries.py
+++ b/flagger/queries.py
@@ -18,3 +18,4 @@ def find_aliases():
         for route in routes:
             for domain in route.domain_external_list():
                 domain_cdns.append((domain, route.domain_internal))
+    return domain_cdns


### PR DESCRIPTION
## Changes proposed in this pull request:

- add DNS preloading to the flagger script. fixes #77 


I'm not 100% sure I like doing it this way, since it might get kinda funky with the ALB instances. I also considered doing these updates as part of the migrator itself. The upsides there are that it's easier to test and we have more logic available to us. The downsides are that we could end up racking up a bit of route53 upsert API charges (although I don't think it'd be too bad) and that I'd have to rewrite it.

## Security considerations

None