### PR TITLE
Add `migration` function for `DomainMigration`

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -66,6 +66,9 @@ jobs:
         ENV: development
         DNS_ROOT_DOMAIN: ((dev-dns-root-domain))
         DATABASE_ENCRYPTION_KEY: ((dev-database-encryption-key))
+        AWS_GOVCLOUD_REGION: ((dev-aws-govcloud-region))
+        AWS_GOVCLOUD_ACCESS_KEY_ID: ((dev-aws-govcloud-access-key-id))
+        AWS_GOVCLOUD_SECRET_ACCESS_KEY: ((dev-aws-govcloud-secret-access-key))
         AWS_COMMERCIAL_REGION: ((dev-aws-commercial-region))
         AWS_COMMERCIAL_ACCESS_KEY_ID: ((dev-aws-commercial-access-key-id))
         AWS_COMMERCIAL_SECRET_ACCESS_KEY: ((dev-aws-commercial-secret-access-key))
@@ -120,6 +123,9 @@ jobs:
         ENV: staging
         DNS_ROOT_DOMAIN: ((staging-dns-root-domain))
         DATABASE_ENCRYPTION_KEY: ((staging-database-encryption-key))
+        AWS_GOVCLOUD_REGION: ((staging-aws-govcloud-region))
+        AWS_GOVCLOUD_ACCESS_KEY_ID: ((staging-aws-govcloud-access-key-id))
+        AWS_GOVCLOUD_SECRET_ACCESS_KEY: ((staging-aws-govcloud-secret-access-key))
         AWS_COMMERCIAL_REGION: ((staging-aws-commercial-region))
         AWS_COMMERCIAL_ACCESS_KEY_ID: ((staging-aws-commercial-access-key-id))
         AWS_COMMERCIAL_SECRET_ACCESS_KEY: ((staging-aws-commercial-secret-access-key))

--- a/migrator/config.py
+++ b/migrator/config.py
@@ -35,6 +35,9 @@ class LocalConfig(Config):
         self.AWS_COMMERCIAL_REGION = "us-west-1"
         self.AWS_COMMERCIAL_ACCESS_KEY_ID = "ASIANOTAREALKEY"
         self.AWS_COMMERCIAL_SECRET_ACCESS_KEY = "THIS_IS_A_FAKE_KEY"
+        self.AWS_GOVCLOUD_REGION = "us-gov-west-1"
+        self.AWS_GOVCLOUD_ACCESS_KEY_ID = "ASIANOTAREALKEYGOV"
+        self.AWS_GOVCLOUD_SECRET_ACCESS_KEY = "THIS_IS_A_FAKE_KEY_GOV"
         self.ROUTE53_ZONE_ID = "FAKEZONEID"
         # https://docs.aws.amazon.com/Route53/latest/APIReference/API_AliasTarget.html
         self.CLOUDFRONT_HOSTED_ZONE_ID = "Z2FDTNDATAQYW2"
@@ -64,6 +67,11 @@ class AppConfig(Config):
         )
         self.AWS_COMMERCIAL_SECRET_ACCESS_KEY = self.env_parser(
             "AWS_COMMERCIAL_SECRET_ACCESS_KEY"
+        )
+        self.AWS_GOVCLOUD_REGION = self.env_parser("AWS_GOVCLOUD_REGION")
+        self.AWS_GOVCLOUD_ACCESS_KEY_ID = self.env_parser("AWS_GOVCLOUD_ACCESS_KEY_ID")
+        self.AWS_GOVCLOUD_SECRET_ACCESS_KEY = self.env_parser(
+            "AWS_GOVCLOUD_SECRET_ACCESS_KEY"
         )
         self.ROUTE53_ZONE_ID = self.env_parser("ROUTE53_HOSTED_ZONE_ID")
         self.ALB_HOSTED_ZONE_ID = self.env_parser("ALB_HOSTED_ZONE_ID")

--- a/migrator/extensions.py
+++ b/migrator/extensions.py
@@ -16,7 +16,15 @@ cloudfront = commercial_session.client("cloudfront")
 iam_commercial = commercial_session.client("iam")
 route53 = commercial_session.client("route53")
 
+govcloud_session = boto3.Session(
+    region_name=config.AWS_GOVCLOUD_REGION,
+    aws_access_key_id=config.AWS_GOVCLOUD_ACCESS_KEY_ID,
+    aws_secret_access_key=config.AWS_GOVCLOUD_SECRET_ACCESS_KEY,
+)
+iam_govcloud = govcloud_session.client("iam")
+
 migration_plan_guid = "739e78F5-a919-46ef-9193-1293cc086c17"
 migration_plan_instance_name = "external-domain-broker-migrator"
 
 domain_with_cdn_plan_guid = "1cc78b0c-c296-48f5-9182-0b38404f79ef"
+domain_plan_guid = "6f60835c-8964-4f1f-a19a-579fb27ce694"

--- a/migrator/models.py
+++ b/migrator/models.py
@@ -105,7 +105,9 @@ class DomainRoute(DomainBase):
     user_data_id = sa.Column(sa.Integer)
     alb_proxy_arn = sa.Column(sa.Text, sa.ForeignKey(DomainAlbProxy.alb_arn))
     alb_proxy = orm.relationship(DomainAlbProxy)
-    certificates = orm.relationship("DomainCertificate")
+    certificates = orm.relationship(
+        "DomainCertificate", order_by="desc(DomainCertificate.expires)"
+    )
 
     def domain_external_list(self):
         """to match CdnRoute"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from tests.lib.database import clean_db
 from tests.lib.dns import dns
 from tests.lib.fake_cf import fake_cf_client
 from tests.lib.fake_cloudfront import cloudfront
-from tests.lib.fake_iam import iam_commercial
+from tests.lib.fake_iam import iam_commercial, iam_govcloud
 from tests.lib.fake_route53 import route53
 from migrator.models import CdnRoute
 from migrator.migration import CdnMigration, Migration

--- a/tests/lib/fake_iam.py
+++ b/tests/lib/fake_iam.py
@@ -1,6 +1,7 @@
 import datetime
 import pytest
 from migrator.extensions import iam_commercial as real_iam_commercial
+from migrator.extensions import iam_govcloud as real_iam_govcloud
 
 from tests.lib.fake_aws import FakeAWS
 
@@ -98,4 +99,10 @@ class FakeIAM(FakeAWS):
 @pytest.fixture
 def iam_commercial():
     with FakeIAM.stubbing(real_iam_commercial) as iam_stubber:
+        yield iam_stubber
+
+
+@pytest.fixture
+def iam_govcloud():
+    with FakeIAM.stubbing(real_iam_govcloud) as iam_stubber:
         yield iam_stubber

--- a/tests/unit/test_cdn_migration.py
+++ b/tests/unit/test_cdn_migration.py
@@ -1057,7 +1057,8 @@ def test_migration_migrates_happy_path(
     } """
 
     fake_requests.delete(
-        "http://localhost/v2/service_instances/asdf-asdf?purge=true", text=response_body
+        "http://localhost/v2/service_instances/asdf-asdf?purge=true",
+        text=purge_service_instance_body,
     )
 
     response_body_update_instance_name = """

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -73,6 +73,9 @@ def mocked_env(vcap_application, vcap_services, monkeypatch):
     monkeypatch.setenv("AWS_COMMERCIAL_REGION", "us-west-1")
     monkeypatch.setenv("AWS_COMMERCIAL_ACCESS_KEY_ID", "ASIANOTAREALKEY")
     monkeypatch.setenv("AWS_COMMERCIAL_SECRET_ACCESS_KEY", "NOT_A_REAL_SECRET_KEY")
+    monkeypatch.setenv("AWS_GOVCLOUD_REGION", "us-gov-west-1")
+    monkeypatch.setenv("AWS_GOVCLOUD_ACCESS_KEY_ID", "ASIANOTAREALKEYGOV")
+    monkeypatch.setenv("AWS_GOVCLOUD_SECRET_ACCESS_KEY", "NOT_A_REAL_SECRET_KEY_GOV")
     monkeypatch.setenv("ROUTE53_HOSTED_ZONE_ID", "FAKEZONEID")
     monkeypatch.setenv("ALB_HOSTED_ZONE_ID", "FAKEZONEIDFORALBS")
     monkeypatch.setenv("CF_USERNAME", "fake_cf_username")
@@ -103,6 +106,9 @@ def test_config_gets_credentials(env, monkeypatch, mocked_env):
     assert config.AWS_COMMERCIAL_REGION == "us-west-1"
     assert config.AWS_COMMERCIAL_ACCESS_KEY_ID == "ASIANOTAREALKEY"
     assert config.AWS_COMMERCIAL_SECRET_ACCESS_KEY == "NOT_A_REAL_SECRET_KEY"
+    assert config.AWS_GOVCLOUD_REGION == "us-gov-west-1"
+    assert config.AWS_GOVCLOUD_ACCESS_KEY_ID == "ASIANOTAREALKEYGOV"
+    assert config.AWS_GOVCLOUD_SECRET_ACCESS_KEY == "NOT_A_REAL_SECRET_KEY_GOV"
     assert config.ROUTE53_ZONE_ID == "FAKEZONEID"
     assert config.CF_USERNAME == "fake_cf_username"
     assert config.CF_PASSWORD == "fake_cf_password"

--- a/tests/unit/test_domain_migration.py
+++ b/tests/unit/test_domain_migration.py
@@ -1,0 +1,554 @@
+import datetime
+
+import pytest
+
+from migrator.models import DomainRoute, DomainAlbProxy, DomainCertificate
+from migrator.migration import DomainMigration
+
+
+@pytest.fixture
+def domain_route(clean_db):
+    proxy = DomainAlbProxy()
+    proxy.alb_arn = "arn:123"
+    proxy.alb_dns_name = "foo.example.com"
+    proxy.listener_arn = "arn:234"
+
+    route = DomainRoute()
+    route.state = "provisioned"
+    route.domains = ["www0.example.gov", "www1.example.gov"]
+    route.instance_id = "asdf-asdf"
+    route.alb_proxy = proxy
+
+    certificate = DomainCertificate()
+    certificate.route = route
+    certificate.name = "my-cert-name"
+    certificate.arn = "my-cert-arn"
+    return route
+
+
+@pytest.fixture
+def domain_migration(clean_db, fake_cf_client, fake_requests, domain_route):
+    return subtest_migration_instantiable(
+        clean_db, fake_cf_client, fake_requests, domain_route
+    )
+
+
+def test_gets_certificate_data(iam_govcloud, domain_migration):
+    iam_govcloud.expect_get_server_certificate("my-cert-name", "my-cert-id-but-longer")
+    assert domain_migration.iam_certificate_id == "my-cert-id-but-longer"
+
+
+def test_gets_active_cert(clean_db, domain_migration):
+    route = domain_migration.route
+    cert = route.certificates[0]
+    cert.expires = datetime.datetime.now()
+
+    certificate0 = DomainCertificate()
+    certificate0.route = route
+    certificate0.name = "my-cert-name-0"
+    certificate0.arn = "my-cert-arn-0"
+    certificate0.expires = datetime.datetime.now() + datetime.timedelta(days=1)
+
+    certificate1 = DomainCertificate()
+    certificate1.route = route
+    certificate1.name = "my-cert-name-2"
+    certificate1.arn = "my-cert-arn-2"
+    certificate1.expires = datetime.datetime.now() - datetime.timedelta(days=1)
+
+    clean_db.add(route)
+    clean_db.add(cert)
+    clean_db.add(certificate0)
+    clean_db.add(certificate1)
+    clean_db.commit()
+    clean_db.expunge_all()
+    route = clean_db.query(DomainRoute).filter_by(instance_id="asdf-asdf").first()
+    domain_migration.route = route
+    assert domain_migration.current_certificate.arn == "my-cert-arn-0"
+
+
+def subtest_migration_instantiable(
+    clean_db, fake_cf_client, fake_requests, domain_route
+):
+    response_body = """
+{
+  "metadata": {
+    "guid": "asdf-asdf",
+    "url": "/v2/service_instances/asdf-asdf",
+    "created_at": "2016-06-08T16:41:29Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "my-old-cdn",
+    "credentials": { },
+    "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
+    "space_guid": "my-space-guid",
+    "gateway_data": null,
+    "dashboard_url": null,
+    "type": "managed_service_instance",
+    "last_operation": {
+      "type": "create",
+      "state": "succeeded",
+      "description": "",
+      "updated_at": "2016-06-08T16:41:26Z",
+      "created_at": "2016-06-08T16:41:29Z"
+    },
+    "space_url": "/v2/spaces/my-space-guid",
+    "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
+    "service_bindings_url": "/v2/service_instances/my-migrator-instance/service_bindings",
+    "service_keys_url": "/v2/service_instances/my-migrator-instance/service_keys",
+    "routes_url": "/v2/service_instances/my-migrator-instance/routes",
+    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+    "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
+  }
+}
+    """
+    fake_requests.get(
+        "http://localhost/v2/service_instances/asdf-asdf", text=response_body
+    )
+    migration = DomainMigration(domain_route, clean_db, fake_cf_client)
+
+    assert fake_requests.called
+    assert fake_requests.request_history[0].method == "GET"
+    assert (
+        fake_requests.request_history[0].url
+        == "http://localhost/v2/service_instances/asdf-asdf"
+    )
+    # reset the mock in subtests to make it easier to reason about
+    fake_requests.reset_mock()
+    return migration
+
+
+def test_domain_migration_migrates(
+    clean_db, fake_cf_client, fake_requests, domain_route
+):
+    """
+    Migrate should:
+    - enable the migration plan
+    - create a migration instance
+    - wait for the migration instance to be created
+    - call update on the migration instance
+    - wait for the update to complete
+    - mark the old instance migrated
+    - call purge on the old instance
+    - disable the migration plan
+    """
+    migration = subtest_migration_instantiable(
+        clean_db, fake_cf_client, fake_requests, domain_route
+    )
+
+    # load caches so we can slim this test down.
+    # We've already tested calls and lazy-loading elsewhere, so we can skip the mocks here
+    migration._space_id = "my-space-id"
+    migration._org_id = "my-org-id"
+    migration._iam_server_certificate_data = {
+        "Path": "/",
+        "ServerCertificateName": "my-server-cert",
+        "ServerCertificateId": "my-server-cert-id",
+        "Arn": "aws:arn:iam:my-server-cert",
+        "UploadDate": datetime.date(2021, 1, 1),
+        "Expiration": datetime.date(2022, 1, 1),
+    }
+
+    create_service_plan_visibility_response_body = """
+    {
+        "metadata": {
+            "guid": "new-plan-visibility-guid",
+            "url": "/v2/service_plan_visibilities/new-plan-visibility-guid",
+            "created_at": "2016-06-08T16:41:31Z",
+            "updated_at": "2016-06-08T16:41:26Z"
+        },
+        "entity": {
+            "service_plan_guid": "foo",
+            "organization_guid": "bar",
+            "service_plan_url": "/v2/service_plans/foo",
+            "organization_url": "/v2/organizations/bar"
+        }
+    }
+    """
+    fake_requests.post(
+        "http://localhost/v2/service_plan_visibilities",
+        text=create_service_plan_visibility_response_body,
+    )
+
+    create_service_instance_response_body = """
+    {
+        "metadata": {
+            "guid": "my-migrator-instance",
+            "url": "/v2/service_instances/my-migrator-instance",
+            "created_at": "2016-06-08T16:41:29Z",
+            "updated_at": "2016-06-08T16:41:26Z"
+        },
+        "entity": {
+            "name": "external-domain-broker-migrator",
+            "credentials": { },
+            "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
+            "space_guid": "my-space-guid",
+            "gateway_data": null,
+            "dashboard_url": null,
+            "type": "managed_service_instance",
+            "last_operation": {
+                "type": "create",
+                "state": "in progress",
+                "description": "",
+                "updated_at": "2016-06-08T16:41:26Z",
+                "created_at": "2016-06-08T16:41:29Z"
+            },
+            "space_url": "/v2/spaces/my-space-1-guid",
+            "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
+            "service_bindings_url": "/v2/service_instances/my-migrator-instance/service_bindings",
+            "service_keys_url": "/v2/service_instances/my-migrator-instance/service_keys",
+            "routes_url": "/v2/service_instances/my-migrator-instance/routes",
+            "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+            "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
+        }
+    }
+    """
+    fake_requests.post(
+        "http://localhost/v2/service_instances",
+        text=create_service_instance_response_body,
+    )
+
+    service_instance_update_check_response_body = """
+    {
+      "metadata": {
+        "guid": "my-migrator-instance",
+        "url": "/v2/service_instances/my-migrator-instance",
+        "created_at": "2016-06-08T16:41:29Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "name": "external-domain-broker-migrator",
+        "credentials": { },
+        "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
+        "space_guid": "my-space-guid",
+        "gateway_data": null,
+        "dashboard_url": null,
+        "type": "managed_service_instance",
+        "last_operation": {
+            "type": "update",
+            "state": "succeeded",
+            "description": "",
+            "updated_at": "2016-06-08T16:41:26Z",
+            "created_at": "2016-06-08T16:41:29Z"
+        },
+        "space_url": "/v2/spaces/my-space-guid",
+        "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
+        "service_bindings_url": "/v2/service_instances/my-migrator-instance/service_bindings",
+        "service_keys_url": "/v2/service_instances/my-migrator-instance/service_keys",
+        "routes_url": "/v2/service_instances/my-migrator-instance/routes",
+        "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+        "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
+      }
+    }"""
+
+    fake_requests.get(
+        "http://localhost/v2/service_instances/my-migrator-instance",
+        text=service_instance_update_check_response_body,
+    )
+    update_service_instance_response_body = """
+    {
+        "metadata": {
+            "guid": "my-migrator-instance",
+            "url": "/v2/service_instances/my-migrator-instance",
+            "created_at": "2016-06-08T16:41:30Z",
+            "updated_at": "2016-06-08T16:41:26Z"
+        },
+        "entity": {
+            "name": "external-domain-broker-migrator",
+            "credentials": { },
+            "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
+            "space_guid": "my-space-guid",
+            "gateway_data": null,
+            "dashboard_url": null,
+            "type": "managed_service_instance",
+            "last_operation": {
+                "type": "update",
+                "state": "in progress",
+                "description": "",
+                "updated_at": "2016-06-08T16:41:30Z",
+                "created_at": "2016-06-08T16:41:30Z"
+            },
+            "tags": [ ],
+            "maintenance_info": {
+                "version": "2.1.0",
+                "description": "OS image update. Expect downtime."
+            },
+            "space_url": "/v2/spaces/my-space-guid",
+            "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
+            "service_bindings_url": "/v2/service_instances/my-migrator-instance/service_bindings",
+            "service_keys_url": "/v2/service_instances/my-migrator-instance/service_keys",
+            "routes_url": "/v2/service_instances/my-migrator-instance/routes",
+            "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+            "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
+        }
+    }"""
+
+    fake_requests.put(
+        "http://localhost/v2/service_instances/my-migrator-instance",
+        text=update_service_instance_response_body,
+    )
+    service_instance_update_check_response_body = """
+    {
+        "metadata": {
+            "guid": "my-migrator-instance",
+            "url": "/v2/service_instances/my-migrator-instance",
+            "created_at": "2016-06-08T16:41:29Z",
+            "updated_at": "2016-06-08T16:41:26Z"
+        },
+        "entity": {
+            "name": "external-domain-broker-migrator",
+            "credentials": { },
+            "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
+            "space_guid": "my-space-guid",
+            "gateway_data": null,
+            "dashboard_url": null,
+            "type": "managed_service_instance",
+            "last_operation": {
+                "type": "update",
+                "state": "succeeded",
+                "description": "",
+                "updated_at": "2016-06-08T16:41:26Z",
+                "created_at": "2016-06-08T16:41:29Z"
+            },
+            "space_url": "/v2/spaces/my-space-guid",
+            "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
+            "service_bindings_url": "/v2/service_instances/my-migrator-instance/service_bindings",
+            "service_keys_url": "/v2/service_instances/my-migrator-instance/service_keys",
+            "routes_url": "/v2/service_instances/my-migrator-instance/routes",
+            "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+            "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
+        }
+    }"""
+
+    fake_requests.get(
+        "http://localhost/v2/service_instances/my-migrator-instance",
+        text=service_instance_update_check_response_body,
+    )
+
+    service_visibilities_response = """
+    {
+       "total_results": 1,
+       "total_pages": 1,
+       "prev_url": null,
+       "next_url": null,
+       "resources": [
+            {
+                "metadata": {
+                    "guid": "my-service-plan-visibility",
+                    "url": "/v2/service_plan_visibilities/my-service-plan-visibility",
+                    "created_at": "2021-02-22T21:15:57Z",
+                    "updated_at": "2021-02-22T21:15:57Z"
+                },
+                "entity": {
+                    "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
+                    "organization_guid": "my-org-guid",
+                    "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
+                    "organization_url": "/v2/organizations/my-org-guid"
+                }
+            }
+       ]
+    }
+    """
+    fake_requests.get(
+        "http://localhost/v2/service_plan_visibilities?q=organization_guid:my-org-id&q=service_plan_guid:739e78F5-a919-46ef-9193-1293cc086c17",
+        text=service_visibilities_response,
+    )
+    response_body = ""
+    fake_requests.delete(
+        "http://localhost/v2/service_plan_visibilities/my-service-plan-visibility",
+        text=response_body,
+    )
+
+    purge_service_instance_body = """{
+        "metadata": {
+            "guid": "asdf-asdf",
+            "url": "/v2/service_instances/asdf-asdf",
+            "created_at": "2016-06-08T16:41:29Z",
+            "updated_at": "2016-06-08T16:41:26Z"
+        },
+        "entity": {
+            "name": "name-1502",
+            "credentials": { },
+            "service_plan_guid": "8ea19d29-2e20-469e-8b91-917a6410e2f2",
+            "space_guid": "dd68a2ba-04a3-4125-99ea-643b96e07ef6",
+            "gateway_data": null,
+            "dashboard_url": null,
+            "type": "managed_service_instance",
+            "last_operation": {
+                "type": "delete",
+                "state": "complete",
+                "description": "",
+                "updated_at": "2016-06-08T16:41:29Z",
+                "created_at": "2016-06-08T16:41:29Z"
+            },
+            "tags": [ ],
+            "maintenance_info": {},
+            "space_url": "/v2/spaces/dd68a2ba-04a3-4125-99ea-643b96e07ef6",
+            "service_plan_url": "/v2/service_plans/8ea19d29-2e20-469e-8b91-917a6410e2f2",
+            "service_bindings_url": "/v2/service_instances/1aaeb02d-16c3-4405-bc41-80e83d196dff/service_bindings",
+            "service_keys_url": "/v2/service_instances/1aaeb02d-16c3-4405-bc41-80e83d196dff/service_keys",
+            "routes_url": "/v2/service_instances/1aaeb02d-16c3-4405-bc41-80e83d196dff/routes",
+            "shared_from_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/shared_from",
+            "shared_to_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/shared_to"
+        }
+
+    }"""
+
+    fake_requests.delete(
+        "http://localhost/v2/service_instances/asdf-asdf?purge=true",
+        text=purge_service_instance_body,
+    )
+
+    response_body_update_instance_name = """
+    {
+        "metadata": {
+            "guid": "my-migrator-instance",
+            "url": "/v2/service_instances/my-migrator-instance",
+            "created_at": "2016-06-08T16:41:29Z",
+            "updated_at": "2016-06-08T16:41:26Z"
+        },
+        "entity": {
+            "name": "external-domain-broker-migrator",
+            "credentials": { },
+            "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
+            "space_guid": "my-space-guid",
+            "gateway_data": null,
+            "dashboard_url": null,
+            "type": "managed_service_instance",
+            "last_operation": {
+                "type": "update",
+                "state": "in progress",
+                "description": "",
+                "updated_at": "2016-06-08T16:41:26Z",
+                "created_at": "2016-06-08T16:41:29Z"
+            },
+            "space_url": "/v2/spaces/my-space-guid",
+            "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
+            "service_bindings_url": "/v2/service_instances/my-migrator-instance/service_bindings",
+            "service_keys_url": "/v2/service_instances/my-migrator-instance/service_keys",
+            "routes_url": "/v2/service_instances/my-migrator-instance/routes",
+            "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+            "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
+        }
+    }
+    """
+    response_body_check_instance = """
+    {
+        "metadata": {
+            "guid": "my-migrator-instance",
+            "url": "/v2/service_instances/my-migrator-instance",
+            "created_at": "2016-06-08T16:41:29Z",
+            "updated_at": "2016-06-08T16:41:26Z"
+        },
+        "entity": {
+            "name": "my-old-cdn",
+            "credentials": { },
+            "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
+            "space_guid": "my-space-guid",
+            "gateway_data": null,
+            "dashboard_url": null,
+            "type": "managed_service_instance",
+            "last_operation": {
+                "type": "update",
+                "state": "succeeded",
+                "description": "",
+                "updated_at": "2016-06-08T16:41:26Z",
+                "created_at": "2016-06-08T16:41:29Z"
+            },
+            "space_url": "/v2/spaces/my-space-guid",
+            "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
+            "service_bindings_url": "/v2/service_instances/my-migrator-instance/service_bindings",
+            "service_keys_url": "/v2/service_instances/my-migrator-instance/service_keys",
+            "routes_url": "/v2/service_instances/my-migrator-instance/routes",
+            "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+            "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
+        }
+    }
+    """
+
+    def name_matcher(request):
+        return request.json().get("name") == "my-old-alb"
+
+    fake_requests.put(
+        "http://localhost/v2/service_instances/my-migrator-instance",
+        text=response_body_update_instance_name,
+        additional_matcher=name_matcher,
+    )
+
+    fake_requests.get(
+        "http://localhost/v2/service_instances/my-migrator-instance",
+        text=response_body_check_instance,
+    )
+
+    migration.migrate()
+
+    # enable service plan
+    assert (
+        fake_requests.request_history[0].url
+        == "http://localhost/v2/service_plan_visibilities"
+    )
+    assert fake_requests.request_history[0].method == "POST"
+
+    # create service instance
+    assert (
+        fake_requests.request_history[1].url == "http://localhost/v2/service_instances"
+    )
+    assert fake_requests.request_history[1].method == "POST"
+
+    # wait for service instance
+    assert (
+        fake_requests.request_history[2].url
+        == "http://localhost/v2/service_instances/my-migrator-instance"
+    )
+    assert fake_requests.request_history[2].method == "GET"
+
+    # update service instance
+    assert (
+        fake_requests.request_history[3].url
+        == "http://localhost/v2/service_instances/my-migrator-instance"
+    )
+    assert fake_requests.request_history[3].method == "PUT"
+    # wait for instance
+    assert (
+        fake_requests.request_history[4].url
+        == "http://localhost/v2/service_instances/my-migrator-instance"
+    )
+    assert fake_requests.request_history[4].method == "GET"
+
+    # find service plan visibility
+    assert (
+        fake_requests.request_history[5].url
+        == "http://localhost/v2/service_plan_visibilities?q=organization_guid%3Amy-org-id&q=service_plan_guid%3A739e78F5-a919-46ef-9193-1293cc086c17"
+    )
+    assert fake_requests.request_history[5].method == "GET"
+
+    # delete service plan visibility
+    assert (
+        fake_requests.request_history[6].url
+        == "http://localhost/v2/service_plan_visibilities/my-service-plan-visibility"
+    )
+    assert fake_requests.request_history[6].method == "DELETE"
+
+    # purge old instance
+    assert (
+        fake_requests.request_history[7].url
+        == "http://localhost/v2/service_instances/asdf-asdf?purge=true"
+    )
+    assert fake_requests.request_history[7].method == "DELETE"
+
+    # rename new instance
+    assert fake_requests.request_history[8].method == "PUT"
+    assert (
+        fake_requests.request_history[8].url
+        == "http://localhost/v2/service_instances/my-migrator-instance"
+    )
+
+    # check rename status
+    assert fake_requests.request_history[9].method == "GET"
+    assert (
+        fake_requests.request_history[9].url
+        == "http://localhost/v2/service_instances/my-migrator-instance"
+    )
+
+    # make sure we're all done
+    assert migration.route.state == "migrated"


### PR DESCRIPTION

## Changes proposed in this pull request:

- add `migration` function for `DomainMigration` fixes #98 
- add active certificate logic to `DomainMigration`
- move `migration` function to `Migration`, wrapping
  `DomainMigration::_migration` an `CdnMigration::_migration`
- add govcloud iam config


## Security considerations

None