### PR TITLE
use plan id rather than catalog id, since that's what CAPI wants

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -84,6 +84,7 @@ jobs:
         SMTP_PASS: ((dev-smtp-pass))
         SMTP_PORT: ((dev-smtp-port))
         SMTP_TO: ((dev-smtp-to))
+        MIGRATION_PLAN_ID: ((dev-migration-plan-id))
 
   on_failure:
     put: slack
@@ -141,6 +142,7 @@ jobs:
         SMTP_PASS: ((staging-smtp-pass))
         SMTP_PORT: ((staging-smtp-port))
         SMTP_TO: ((staging-smtp-to))
+        MIGRATION_PLAN_ID: ((staging-migration-plan-id))
 
   on_failure:
     put: slack

--- a/migrator/config.py
+++ b/migrator/config.py
@@ -52,6 +52,7 @@ class LocalConfig(Config):
         self.SERVICE_CHANGE_RETRY_COUNT = 2
         self.SERVICE_CHANGE_POLL_TIME_SECONDS = 0.01
         self.MIGRATION_TIME = "11:00:00"
+        self.MIGRATION_PLAN_ID = "FAKE-MIGRATION-PLAN-GUID"
 
 
 class AppConfig(Config):
@@ -85,6 +86,7 @@ class AppConfig(Config):
         self.SERVICE_CHANGE_RETRY_COUNT = 60
         self.SERVICE_CHANGE_POLL_TIME_SECONDS = 10
         self.MIGRATION_TIME = self.env_parser("MIGRATION_TIME", "11:00:00")
+        self.MIGRATION_PLAN_ID = self.env_parser("MIGRATION_PLAN_ID")
 
         self.SMTP_HOST = self.env_parser("SMTP_HOST")
         self.SMTP_FROM = self.env_parser("SMTP_FROM")

--- a/migrator/migration.py
+++ b/migrator/migration.py
@@ -142,11 +142,11 @@ class Migration:
     @property
     def service_plan_visibility_ids(self):
         return cf.get_service_plan_visibility_ids_for_org(
-            migration_plan_guid, self.org_id, self.client
+            config.MIGRATION_PLAN_ID, self.org_id, self.client
         )
 
     def enable_migration_service_plan(self):
-        cf.enable_plan_for_org(migration_plan_guid, self.org_id, self.client)
+        cf.enable_plan_for_org(config.MIGRATION_PLAN_ID, self.org_id, self.client)
 
     def disable_migration_service_plan(self):
         for service_plan_visibility_id in self.service_plan_visibility_ids:

--- a/tests/unit/test_cdn_migration.py
+++ b/tests/unit/test_cdn_migration.py
@@ -1012,7 +1012,7 @@ def test_migration_migrates_happy_path(
 }
     """
     fake_requests.get(
-        "http://localhost/v2/service_plan_visibilities?q=organization_guid:my-org-id&q=service_plan_guid:739e78F5-a919-46ef-9193-1293cc086c17",
+        "http://localhost/v2/service_plan_visibilities?q=organization_guid:my-org-id&q=service_plan_guid:FAKE-MIGRATION-PLAN-GUID",
         text=service_visibilities_response,
     )
     response_body = ""
@@ -1174,7 +1174,7 @@ def test_migration_migrates_happy_path(
     assert fake_requests.request_history[7].method == "GET"
     assert (
         fake_requests.request_history[8].url
-        == "http://localhost/v2/service_plan_visibilities?q=organization_guid%3Amy-org-id&q=service_plan_guid%3A739e78F5-a919-46ef-9193-1293cc086c17"
+        == "http://localhost/v2/service_plan_visibilities?q=organization_guid%3Amy-org-id&q=service_plan_guid%3AFAKE-MIGRATION-PLAN-GUID"
     )
     assert fake_requests.request_history[8].method == "GET"
     assert (

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -88,6 +88,7 @@ def mocked_env(vcap_application, vcap_services, monkeypatch):
     monkeypatch.setenv("SMTP_FROM", "no-reply@example.com")
     monkeypatch.setenv("SMTP_TO", "alerts@example.com")
     monkeypatch.setenv("SMTP_CERT", "A_REAL_CERT_WOULD_BE_LONGER_THAN_THIS")
+    monkeypatch.setenv("MIGRATION_PLAN_ID", "A_MIGRATION_PLAN_ID")
 
 
 @pytest.mark.parametrize("env", ["local", "development", "staging", "production"])
@@ -115,6 +116,7 @@ def test_config_gets_credentials(env, monkeypatch, mocked_env):
     assert config.CF_API_ENDPOINT == "https://localhost"
     assert config.ALB_HOSTED_ZONE_ID == "FAKEZONEIDFORALBS"
     assert config.CLOUDFRONT_HOSTED_ZONE_ID == "Z2FDTNDATAQYW2"
+    assert config.MIGRATION_PLAN_ID == "A_MIGRATION_PLAN_ID"
 
 
 @pytest.mark.parametrize("env", ["production", "staging", "development"])

--- a/tests/unit/test_domain_migration.py
+++ b/tests/unit/test_domain_migration.py
@@ -350,7 +350,7 @@ def test_domain_migration_migrates(
     }
     """
     fake_requests.get(
-        "http://localhost/v2/service_plan_visibilities?q=organization_guid:my-org-id&q=service_plan_guid:739e78F5-a919-46ef-9193-1293cc086c17",
+        "http://localhost/v2/service_plan_visibilities?q=organization_guid:my-org-id&q=service_plan_guid:FAKE-MIGRATION-PLAN-GUID",
         text=service_visibilities_response,
     )
     response_body = ""
@@ -518,7 +518,7 @@ def test_domain_migration_migrates(
     # find service plan visibility
     assert (
         fake_requests.request_history[5].url
-        == "http://localhost/v2/service_plan_visibilities?q=organization_guid%3Amy-org-id&q=service_plan_guid%3A739e78F5-a919-46ef-9193-1293cc086c17"
+        == "http://localhost/v2/service_plan_visibilities?q=organization_guid%3Amy-org-id&q=service_plan_guid%3AFAKE-MIGRATION-PLAN-GUID"
     )
     assert fake_requests.request_history[5].method == "GET"
 

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -291,7 +291,7 @@ def test_migration_enables_plan_in_org(
 ):
     def service_plan_visibility_matcher(request):
         params = request.json()
-        plan = "739e78F5-a919-46ef-9193-1293cc086c17"
+        plan = "FAKE-MIGRATION-PLAN-GUID"
         return (
             params["organization_guid"] == "my-org-guid"
             and params["service_plan_guid"] == plan
@@ -352,7 +352,7 @@ def test_migration_disables_plan_in_org(
          "entity": {
             "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
             "organization_guid": "my-org-guid",
-            "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
+            "service_plan_url": "/v2/service_plans/FAKE-MIGRATION-PLAN-GUID",
             "organization_url": "/v2/organizations/my-org-guid"
          }
       }
@@ -360,7 +360,7 @@ def test_migration_disables_plan_in_org(
 }
     """
     fake_requests.get(
-        "http://localhost/v2/service_plan_visibilities?q=organization_guid:my-org-guid&q=service_plan_guid:739e78F5-a919-46ef-9193-1293cc086c17",
+        "http://localhost/v2/service_plan_visibilities?q=organization_guid:my-org-guid&q=service_plan_guid:FAKE-MIGRATION-PLAN-GUID",
         text=response_body_get,
     )
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- reference plan id. Catalog id is apparently useless 🤷 
- 
- 

## Security considerations

None