### PR TITLE
set external_domain_broker_service_instance to None so repr always works

### DIFF
--- a/migrator/migration.py
+++ b/migrator/migration.py
@@ -109,6 +109,7 @@ class Migration:
         self._space_id = None
         self._org_id = None
         self._iam_server_certificate_data = None
+        self.external_domain_broker_service_instance = None
 
         # get this early so we're sure we have it before we purge the instance
         self.instance_name = self.get_instance_name()


### PR DESCRIPTION
## Changes proposed in this pull request:

- set `external_domain_broker_service_instance` to `None` so `repr` always works. Right now, if we hit an exception before we have an `external_domain_broekr_service_instance`, the exception handler blows up too and we can't see what happened

## Security considerations

[Note the any security considerations here, or make note of why there are none]
