### PR TITLE
ignore errors caused by existing visibility

### DIFF
--- a/migrator/cf.py
+++ b/migrator/cf.py
@@ -1,5 +1,6 @@
 import logging
 from cloudfoundry_client.client import CloudFoundryClient
+from cloudfoundry_client.errors import InvalidStatusCode
 
 logger = logging.getLogger(__name__)
 
@@ -19,8 +20,11 @@ def get_cf_client(config):
 
 def enable_plan_for_org(plan_id, org_id, client):
     logger.debug("enabling plan for %s", org_id)
-    response = client.v2.service_plan_visibilities.create(plan_id, org_id)
-    return response["metadata"]["guid"]
+    try:
+        response = client.v2.service_plan_visibilities.create(plan_id, org_id)
+    except InvalidStatusCode as e:
+        if e.body["error_code"] != "CF-ServicePlanVisibilityAlreadyExists":
+            raise e
 
 
 def get_service_plan_visibility_ids_for_org(plan_id, org_id, client):

--- a/tests/unit/test_cf.py
+++ b/tests/unit/test_cf.py
@@ -40,6 +40,27 @@ def test_enable_service_plan_2(fake_requests, fake_cf_client):
     assert last_request.url == "http://localhost/v2/service_plan_visibilities"
 
 
+def test_enable_service_plan_2(fake_requests, fake_cf_client):
+    response_body = """{
+        "description": "This combination of ServicePlan and Organization is already taken: organization_id and service_plan_id unique",
+        "error_code": "CF-ServicePlanVisibilityAlreadyExists",
+        "code": 260002
+    }
+    """
+    fake_requests.post(
+        "http://localhost/v2/service_plan_visibilities",
+        text=response_body,
+        status_code=400,
+    )
+
+    # the real test here is that we don't raise an error
+    res = cf.enable_plan_for_org("foo", "bar", fake_cf_client)
+
+    assert fake_requests.called
+    last_request = fake_requests.request_history[-1]
+    assert last_request.url == "http://localhost/v2/service_plan_visibilities"
+
+
 def test_disable_service_plan_2(fake_requests, fake_cf_client):
     response_body = ""
     fake_requests.delete(


### PR DESCRIPTION
catch errors caused by trying to create a service plan visibility that
already exists
don't return the service plan visibility guid, either. We're ignoring
it, and don't have it when we catch a conflict error

## Changes proposed in this pull request:

- catch errors caused by trying to create a service plan visibility that
already exists
- don't return the service plan visibility guid, either. We're ignoring
it, and don't have it when we catch a conflict error


## Security considerations

None