### PR TITLE
normalize postgresql uris for sqlalchemy

### DIFF
--- a/migrator/config.py
+++ b/migrator/config.py
@@ -61,9 +61,9 @@ class AppConfig(Config):
     def __init__(self):
         super().__init__()
         cdn_db = self.cf_env_parser.get_service(name="rds-cdn-broker")
-        self.CDN_BROKER_DATABASE_URI = cdn_db.credentials["uri"]
+        self.CDN_BROKER_DATABASE_URI = normalize_db_url(cdn_db.credentials["uri"])
         alb_db = self.cf_env_parser.get_service(name="rds-domain-broker")
-        self.DOMAIN_BROKER_DATABASE_URI = alb_db.credentials["uri"]
+        self.DOMAIN_BROKER_DATABASE_URI = normalize_db_url(alb_db.credentials["uri"])
         self.DNS_VERIFICATION_SERVER = "8.8.8.8:53"
         self.DNS_ROOT_DOMAIN = self.env_parser("DNS_ROOT_DOMAIN")
         self.AWS_COMMERCIAL_REGION = self.env_parser("AWS_COMMERCIAL_REGION")
@@ -116,3 +116,11 @@ class StagingConfig(AppConfig):
 class ProductionConfig(AppConfig):
     def __init__(self):
         super().__init__()
+
+
+def normalize_db_url(url):
+    # sqlalchemy no longer lets us use postgres://
+    # it requires postgresql://
+    if url.split(":")[0] == "postgres":
+        url = url.replace("postgres:", "postgresql:", 1)
+    return url

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -33,7 +33,7 @@ def vcap_services():
                     "host": "cdn-db-host",
                     "password": "cdn-db-password",
                     "port": "cdn-db-port",
-                    "uri": "cdn-db-uri",
+                    "uri": "postgres://cdn-db-uri",
                     "username": "cdn-db-username",
                 },
                 "instance_name": "rds-cdn-broker",
@@ -50,7 +50,7 @@ def vcap_services():
                     "host": "alb-db-host",
                     "password": "alb-db-password",
                     "port": "alb-db-port",
-                    "uri": "alb-db-uri",
+                    "uri": "postgresql://alb-db-uri",
                     "username": "alb-db-username",
                 },
                 "instance_name": "rds-domain-broker",
@@ -104,8 +104,8 @@ def test_config_doesnt_explode(env, monkeypatch, mocked_env):
 def test_config_gets_credentials(env, monkeypatch, mocked_env):
     monkeypatch.setenv("ENV", env)
     config = config_from_env()
-    assert config.CDN_BROKER_DATABASE_URI == "cdn-db-uri"
-    assert config.DOMAIN_BROKER_DATABASE_URI == "alb-db-uri"
+    assert config.CDN_BROKER_DATABASE_URI == "postgresql://cdn-db-uri"
+    assert config.DOMAIN_BROKER_DATABASE_URI == "postgresql://alb-db-uri"
     assert config.AWS_COMMERCIAL_REGION == "us-west-1"
     assert config.AWS_COMMERCIAL_ACCESS_KEY_ID == "ASIANOTAREALKEY"
     assert config.AWS_COMMERCIAL_SECRET_ACCESS_KEY == "NOT_A_REAL_SECRET_KEY"


### PR DESCRIPTION
## Changes proposed in this pull request:

- sqlalchemy 1.4.x doesn't support postgres:// anymore, so normalize the uris


## Security considerations

None