### PR TITLE
fix versions, use consistent testing protocol

### DIFF
--- a/pip-tools/dev-requirements.txt
+++ b/pip-tools/dev-requirements.txt
@@ -4,11 +4,15 @@
 #
 #    ./dev update-requirements
 #
-aiohttp==3.7.4
+aiohttp==3.9.5
     # via
     #   -r pip-tools/../requirements.txt
     #   cloudfoundry-client
-async-timeout==3.0.1
+aiosignal==1.3.1
+    # via
+    #   -r pip-tools/../requirements.txt
+    #   aiohttp
+async-timeout==4.0.3
     # via
     #   -r pip-tools/../requirements.txt
     #   aiohttp
@@ -18,9 +22,9 @@ attrs==23.2.0
     #   aiohttp
 black==24.4.2
     # via -r pip-tools/dev-requirements.in
-boto3==1.34.123
+boto3==1.34.126
     # via -r pip-tools/../requirements.txt
-botocore==1.34.123
+botocore==1.34.126
     # via
     #   -r pip-tools/../requirements.txt
     #   boto3
@@ -37,10 +41,6 @@ cffi==1.16.0
     # via
     #   -r pip-tools/../requirements.txt
     #   cryptography
-chardet==3.0.4
-    # via
-    #   -r pip-tools/../requirements.txt
-    #   aiohttp
 charset-normalizer==3.3.2
     # via
     #   -r pip-tools/../requirements.txt
@@ -49,7 +49,7 @@ click==8.1.7
     # via
     #   black
     #   pip-tools
-cloudfoundry-client==1.17.0
+cloudfoundry-client==1.37.1
     # via -r pip-tools/../requirements.txt
 colorama==0.4.6
     # via pytest-watch
@@ -65,6 +65,11 @@ exceptiongroup==1.2.1
     # via pytest
 flake8==7.0.0
     # via -r pip-tools/dev-requirements.in
+frozenlist==1.4.1
+    # via
+    #   -r pip-tools/../requirements.txt
+    #   aiohttp
+    #   aiosignal
 furl==2.1.3
     # via
     #   -r pip-tools/../requirements.txt
@@ -102,7 +107,7 @@ multidict==6.0.5
     #   yarl
 mypy-extensions==1.0.0
     # via black
-oauth2-client==1.2.1
+oauth2-client==1.4.2
     # via
     #   -r pip-tools/../requirements.txt
     #   cloudfoundry-client
@@ -125,11 +130,11 @@ platformdirs==4.2.2
     # via black
 pluggy==1.5.0
     # via pytest
-polling2==0.4.6
+polling2==0.5.0
     # via
     #   -r pip-tools/../requirements.txt
     #   cloudfoundry-client
-protobuf==3.20.3
+protobuf==5.27.1
     # via
     #   -r pip-tools/../requirements.txt
     #   cloudfoundry-client
@@ -164,7 +169,7 @@ python-dotenv==1.0.1
     # via
     #   -r pip-tools/../requirements.txt
     #   environs
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
     #   -r pip-tools/../requirements.txt
     #   cloudfoundry-client
@@ -190,7 +195,6 @@ six==1.16.0
     #   orderedmultidict
     #   pytest-profiling
     #   python-dateutil
-    #   websocket-client
 sqlalchemy==2.0.30
     # via
     #   -r pip-tools/../requirements.txt
@@ -206,7 +210,6 @@ tomli==2.0.1
 typing-extensions==4.12.2
     # via
     #   -r pip-tools/../requirements.txt
-    #   aiohttp
     #   black
     #   sqlalchemy
 urllib3==1.26.18
@@ -216,7 +219,7 @@ urllib3==1.26.18
     #   requests
 watchdog==4.0.1
     # via pytest-watch
-websocket-client==0.54.0
+websocket-client==1.8.0
     # via
     #   -r pip-tools/../requirements.txt
     #   cloudfoundry-client

--- a/pip-tools/requirements.in
+++ b/pip-tools/requirements.in
@@ -1,10 +1,8 @@
 boto3
 cfenv
 
-# later versions of cf client break tests. We should probably fix them, but this is good for now
-cloudfoundry-client==1.17.0
-# protobuf 3.21+ is not compatible with cloudfoundry 1.17.0
-protobuf<3.21
+cloudfoundry-client
+protobuf
 cryptography
 dnspython
 environs

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,17 @@
 #
 #    ./dev update-requirements
 #
-aiohttp==3.9.4
+aiohttp==3.9.5
     # via cloudfoundry-client
-async-timeout==3.0.1
+aiosignal==1.3.1
+    # via aiohttp
+async-timeout==4.0.3
     # via aiohttp
 attrs==23.2.0
     # via aiohttp
-boto3==1.34.123
+boto3==1.34.126
     # via -r pip-tools/requirements.in
-botocore==1.34.123
+botocore==1.34.126
     # via
     #   boto3
     #   s3transfer
@@ -22,11 +24,9 @@ cfenv==0.5.3
     # via -r pip-tools/requirements.in
 cffi==1.16.0
     # via cryptography
-chardet==3.0.4
-    # via aiohttp
 charset-normalizer==3.3.2
     # via requests
-cloudfoundry-client==1.17.0
+cloudfoundry-client==1.37.1
     # via -r pip-tools/requirements.in
 cryptography==42.0.8
     # via -r pip-tools/requirements.in
@@ -34,6 +34,10 @@ dnspython==2.6.1
     # via -r pip-tools/requirements.in
 environs==11.0.0
     # via -r pip-tools/requirements.in
+frozenlist==1.4.1
+    # via
+    #   aiohttp
+    #   aiosignal
 furl==2.1.3
     # via cfenv
 greenlet==3.0.3
@@ -52,15 +56,15 @@ multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-oauth2-client==1.2.1
+oauth2-client==1.4.2
     # via cloudfoundry-client
 orderedmultidict==1.0.1
     # via furl
 packaging==24.1
     # via marshmallow
-polling2==0.4.6
+polling2==0.5.0
     # via cloudfoundry-client
-protobuf==3.20.3
+protobuf==5.27.1
     # via
     #   -r pip-tools/requirements.in
     #   cloudfoundry-client
@@ -72,7 +76,7 @@ python-dateutil==2.9.0.post0
     # via botocore
 python-dotenv==1.0.1
     # via environs
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via cloudfoundry-client
 requests==2.32.3
     # via
@@ -87,7 +91,6 @@ six==1.16.0
     #   furl
     #   orderedmultidict
     #   python-dateutil
-    #   websocket-client
 sqlalchemy==2.0.30
     # via
     #   -r pip-tools/requirements.in
@@ -95,14 +98,12 @@ sqlalchemy==2.0.30
 sqlalchemy-utils==0.41.2
     # via -r pip-tools/requirements.in
 typing-extensions==4.12.2
-    # via
-    #   aiohttp
-    #   sqlalchemy
+    # via sqlalchemy
 urllib3==1.26.18
     # via
     #   botocore
     #   requests
-websocket-client==0.54.0
+websocket-client==1.8.0
     # via cloudfoundry-client
 yarl==1.9.4
     # via aiohttp

--- a/tests/lib/fake_cf.py
+++ b/tests/lib/fake_cf.py
@@ -30,19 +30,19 @@ def get_test_client(fake_requests):
                     "logging": None,
                     "log_stream": None,
                     "app_ssh": dict(href="ssh.localhost:80"),
-                    "uaa": dict(href="https://uaa.localhost"),
+                    "uaa": dict(href="http://uaa.localhost"),
                     "network_policy_v0": dict(
-                        href="https://api.localhost/networking/v0/external"
+                        href="http://api.localhost/networking/v0/external"
                     ),
                     "network_policy_v1": dict(
-                        href="https://api.localhost/networking/v1/external"
+                        href="http://api.localhost/networking/v1/external"
                     ),
                 }
             )
         ),
     )
     fake_requests.post(
-        "http://login.localhost/oauth/token",
+        "http://uaa.localhost/oauth/token",
         text=json.dumps(
             dict(access_token="access-token", refresh_token="refresh-token")
         ),


### PR DESCRIPTION


## Changes proposed in this pull request:

- bump versions
- consistently use http for local testing so requests-mock can consistently capture requests

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

newer versions have fewer vulns