### PR TITLE
Address security alerts

### DIFF
--- a/dev
+++ b/dev
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-shopt -s inherit_errexit
+shopt -s inherit_errexit 2>/dev/null || true
 
 built_image_name="external-domain-broker-migrator-dev"
 
 main() {
   [[ $# -eq 0 ]] && usage "Expected command."
-  [[ -v DEBUG ]] && set -x
+  if [[ "${DEBUG+x}" ]] ; then
+    set -x
+  fi
 
   cd "$(git rev-parse --show-toplevel)"
 

--- a/pip-tools/dev-requirements.txt
+++ b/pip-tools/dev-requirements.txt
@@ -22,16 +22,16 @@ attrs==23.2.0
     #   aiohttp
 black==24.4.2
     # via -r pip-tools/dev-requirements.in
-boto3==1.34.126
+boto3==1.34.140
     # via -r pip-tools/../requirements.txt
-botocore==1.34.126
+botocore==1.34.140
     # via
     #   -r pip-tools/../requirements.txt
     #   boto3
     #   s3transfer
 build==1.2.1
     # via pip-tools
-certifi==2024.6.2
+certifi==2024.7.4
     # via
     #   -r pip-tools/../requirements.txt
     #   requests
@@ -63,7 +63,7 @@ environs==11.0.0
     # via -r pip-tools/../requirements.txt
 exceptiongroup==1.2.1
     # via pytest
-flake8==7.0.0
+flake8==7.1.0
     # via -r pip-tools/dev-requirements.in
 frozenlist==1.4.1
     # via
@@ -85,7 +85,7 @@ idna==3.7
     #   -r pip-tools/../requirements.txt
     #   requests
     #   yarl
-importlib-metadata==7.1.0
+importlib-metadata==8.0.0
     # via build
 iniconfig==2.0.0
     # via pytest
@@ -134,13 +134,13 @@ polling2==0.5.0
     # via
     #   -r pip-tools/../requirements.txt
     #   cloudfoundry-client
-protobuf==5.27.1
+protobuf==5.27.2
     # via
     #   -r pip-tools/../requirements.txt
     #   cloudfoundry-client
 psycopg2==2.9.9
     # via -r pip-tools/../requirements.txt
-pycodestyle==2.11.1
+pycodestyle==2.12.0
     # via flake8
 pycparser==2.22
     # via
@@ -182,7 +182,7 @@ requests==2.32.3
     #   requests-mock
 requests-mock==1.12.1
     # via -r pip-tools/dev-requirements.in
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   -r pip-tools/../requirements.txt
     #   boto3
@@ -195,7 +195,7 @@ six==1.16.0
     #   orderedmultidict
     #   pytest-profiling
     #   python-dateutil
-sqlalchemy==2.0.30
+sqlalchemy==2.0.31
     # via
     #   -r pip-tools/../requirements.txt
     #   sqlalchemy-utils
@@ -212,7 +212,7 @@ typing-extensions==4.12.2
     #   -r pip-tools/../requirements.txt
     #   black
     #   sqlalchemy
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   -r pip-tools/../requirements.txt
     #   botocore

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ async-timeout==4.0.3
     # via aiohttp
 attrs==23.2.0
     # via aiohttp
-boto3==1.34.126
+boto3==1.34.140
     # via -r pip-tools/requirements.in
-botocore==1.34.126
+botocore==1.34.140
     # via
     #   boto3
     #   s3transfer
@@ -64,7 +64,7 @@ packaging==24.1
     # via marshmallow
 polling2==0.5.0
     # via cloudfoundry-client
-protobuf==5.27.1
+protobuf==5.27.2
     # via
     #   -r pip-tools/requirements.in
     #   cloudfoundry-client
@@ -82,7 +82,7 @@ requests==2.32.3
     # via
     #   cloudfoundry-client
     #   oauth2-client
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via boto3
 schedule==1.2.2
     # via -r pip-tools/requirements.in
@@ -91,7 +91,7 @@ six==1.16.0
     #   furl
     #   orderedmultidict
     #   python-dateutil
-sqlalchemy==2.0.30
+sqlalchemy==2.0.31
     # via
     #   -r pip-tools/requirements.in
     #   sqlalchemy-utils


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update certifi >= 2024.7.4 to address security alert
- Update urllib 1.26.19 to address security alert

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Addresse active Dependabot security alerts
