### PR TITLE
fix resource name

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -22,10 +22,10 @@ jobs:
     params: {depth: 1}
     trigger: true
     passed: [reconfigure]
-  - get: external-domain-migrator-testing
+  - get: external-domain-broker-migrator-testing
   - task: test
     # Run the tests using the image pushed above.
-    image: external-domain-migrator-testing
+    image: external-domain-broker-migrator-testing
     config:
       platform: linux
       params:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Missed the word `broker` in the resource name when actually using it

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Fixing the resource name
