### PR TITLE
enforce ssl on database connections

### DIFF
--- a/migrator/config.py
+++ b/migrator/config.py
@@ -95,11 +95,19 @@ class AppConfig(Config):
         super().__init__()
         cdn_db = self.cf_env_parser.get_service(name="rds-cdn-broker")
         self.CDN_BROKER_DATABASE_URI = normalize_db_url(cdn_db.credentials["uri"])
+        if not self.CDN_BROKER_DATABASE_URI.endswith("?sslmode=require"):
+            self.CDN_BROKER_DATABASE_URI = (
+                f"{self.CDN_BROKER_DATABASE_URI}?sslmode=require"
+            )
         self.CDN_DATABASE_ENCRYPTION_KEY = self.env_parser(
             "CDN_DATABASE_ENCRYPTION_KEY"
         )
         alb_db = self.cf_env_parser.get_service(name="rds-domain-broker")
         self.DOMAIN_BROKER_DATABASE_URI = normalize_db_url(alb_db.credentials["uri"])
+        if not self.DOMAIN_BROKER_DATABASE_URI.endswith("?sslmode=require"):
+            self.DOMAIN_BROKER_DATABASE_URI = (
+                f"{self.DOMAIN_BROKER_DATABASE_URI}?sslmode=require"
+            )
         self.DOMAIN_DATABASE_ENCRYPTION_KEY = self.env_parser(
             "DOMAIN_DATABASE_ENCRYPTION_KEY"
         )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -103,8 +103,10 @@ def test_config_doesnt_explode(env, monkeypatch, mocked_env):
 def test_config_gets_credentials(env, monkeypatch, mocked_env):
     monkeypatch.setenv("ENV", env)
     config = config_from_env()
-    assert config.CDN_BROKER_DATABASE_URI == "postgresql://cdn-db-uri"
-    assert config.DOMAIN_BROKER_DATABASE_URI == "postgresql://alb-db-uri"
+    assert config.CDN_BROKER_DATABASE_URI == "postgresql://cdn-db-uri?sslmode=require"
+    assert (
+        config.DOMAIN_BROKER_DATABASE_URI == "postgresql://alb-db-uri?sslmode=require"
+    )
     assert config.AWS_COMMERCIAL_REGION == "us-west-1"
     assert config.AWS_COMMERCIAL_ACCESS_KEY_ID == "ASIANOTAREALKEY"
     assert config.AWS_COMMERCIAL_SECRET_ACCESS_KEY == "NOT_A_REAL_SECRET_KEY"


### PR DESCRIPTION
## Changes proposed in this pull request:

- enforce ssl on database connections

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

TLS security will now be enforced for database connections, which improves security
