### PR TITLE
chore: Upgrade service_plan_visibility calls to cf API v3

### DIFF
--- a/migrator/cf.py
+++ b/migrator/cf.py
@@ -20,24 +20,12 @@ def get_cf_client(config):
 
 def enable_plan_for_org(plan_id, org_id, client):
     logger.debug("enabling plan for %s", org_id)
+    orgs = [{"guid": org_id}]
     try:
-        response = client.v3.service_plans.apply_visibility_to_extra_orgs(
-            plan_id, [org_id]
-        )
+        response = client.v3.service_plans.apply_visibility_to_extra_orgs(plan_id, orgs)
     except InvalidStatusCode as e:
         if e.body["error_code"] != "CF-ServicePlanVisibilityAlreadyExists":
             raise e
-
-
-# def get_service_plan_visibility_ids_for_org(plan_id, org_id, client):
-#    logger.debug("getting plan visibilities for %s", org_id)
-#    service_plan_visibilities = client.v2.service_plan_visibilities.list(
-#        service_plan_guid=plan_id, organization_guid=org_id
-#    )
-#    return [
-#        service_plan_visibility["metadata"]["guid"]
-#        for service_plan_visibility in service_plan_visibilities
-#    ]
 
 
 def disable_plan_for_org(plan_id, org_id, client):

--- a/migrator/cf.py
+++ b/migrator/cf.py
@@ -21,26 +21,30 @@ def get_cf_client(config):
 def enable_plan_for_org(plan_id, org_id, client):
     logger.debug("enabling plan for %s", org_id)
     try:
-        response = client.v2.service_plan_visibilities.create(plan_id, org_id)
+        response = client.v3.service_plans.apply_visibility_to_extra_orgs(
+            plan_id, [org_id]
+        )
     except InvalidStatusCode as e:
         if e.body["error_code"] != "CF-ServicePlanVisibilityAlreadyExists":
             raise e
 
 
-def get_service_plan_visibility_ids_for_org(plan_id, org_id, client):
-    logger.debug("getting plan visibilities for %s", org_id)
-    service_plan_visibilities = client.v2.service_plan_visibilities.list(
-        service_plan_guid=plan_id, organization_guid=org_id
-    )
-    return [
-        service_plan_visibility["metadata"]["guid"]
-        for service_plan_visibility in service_plan_visibilities
-    ]
+# def get_service_plan_visibility_ids_for_org(plan_id, org_id, client):
+#    logger.debug("getting plan visibilities for %s", org_id)
+#    service_plan_visibilities = client.v2.service_plan_visibilities.list(
+#        service_plan_guid=plan_id, organization_guid=org_id
+#    )
+#    return [
+#        service_plan_visibility["metadata"]["guid"]
+#        for service_plan_visibility in service_plan_visibilities
+#    ]
 
 
-def disable_plan_for_org(service_plan_visibility_id, client):
+def disable_plan_for_org(plan_id, org_id, client):
     logger.debug("disabling plan visibility")
-    return client.v2.service_plan_visibilities.remove(service_plan_visibility_id)
+    return client.v3.service_plans.remove_org_from_service_plan_visibility(
+        plan_id, org_id
+    )
 
 
 def get_space_id_for_service_instance_id(instance_id, client):

--- a/migrator/models/common.py
+++ b/migrator/models/common.py
@@ -4,14 +4,17 @@ from typing import Union, Type, List
 
 from migrator.extensions import config
 
-if config.ENV == 'unit':
+if config.ENV == "unit":
     from sqlalchemy.dialects import sqlite
+
     blob_or_bytea = sqlite.BLOB
     timestamp = sqlite.TIMESTAMP
 else:
     from sqlalchemy.dialects import postgresql
+
     blob_or_bytea = postgresql.BYTEA
     timestamp = postgresql.TIMESTAMP
+
 
 class Action(str, Enum):
     RENEW = "renew"

--- a/migrator/models/domain.py
+++ b/migrator/models/domain.py
@@ -20,7 +20,7 @@ from migrator.models.common import (
     OperationModel,
     OperationState,
     timestamp,
-    blob_or_bytea
+    blob_or_bytea,
 )
 
 convention = {
@@ -34,12 +34,15 @@ convention = {
 metadata = sa.MetaData(naming_convention=convention)
 DomainModel = orm.declarative_base(metadata=metadata)
 
-if config.ENV == 'unit':
+if config.ENV == "unit":
     from sqlalchemy.dialects import sqlite
+
     text_array = sqlite.JSON
 else:
     from sqlalchemy.dialects import postgresql
+
     text_array = postgresql.ARRAY(sa.Text)
+
 
 def db_encryption_key():
     return config.DOMAIN_DATABASE_ENCRYPTION_KEY

--- a/tests/integration/test_cdn_migration.py
+++ b/tests/integration/test_cdn_migration.py
@@ -850,23 +850,12 @@ def test_migration_migrates_happy_path(
 
     domains = ["example.gov", "foo.com"]
     create_service_plan_visibility_response_body = """
-    {
-  "metadata": {
-    "guid": "new-plan-visibility-guid",
-    "url": "/v2/service_plan_visibilities/new-plan-visibility-guid",
-    "created_at": "2016-06-08T16:41:31Z",
-    "updated_at": "2016-06-08T16:41:26Z"
-  },
-  "entity": {
-    "service_plan_guid": "foo",
-    "organization_guid": "bar",
-    "service_plan_url": "/v2/service_plans/foo",
-    "organization_url": "/v2/organizations/bar"
-  }
+{
+  "type": "organization"
 }
 """
     fake_requests.post(
-        "http://localhost/v2/service_plan_visibilities",
+        "http://localhost/v3/service_plans/FAKE-MIGRATION-PLAN-GUID/visibility",
         text=create_service_plan_visibility_response_body,
     )
 
@@ -1032,37 +1021,9 @@ def test_migration_migrates_happy_path(
         "http://localhost/v2/service_instances/my-migrator-instance",
         text=service_instance_update_check_response_body,
     )
-    service_visibilities_response = """
-{
-   "total_results": 1,
-   "total_pages": 1,
-   "prev_url": null,
-   "next_url": null,
-   "resources": [
-      {
-         "metadata": {
-            "guid": "my-service-plan-visibility",
-            "url": "/v2/service_plan_visibilities/my-service-plan-visibility",
-            "created_at": "2021-02-22T21:15:57Z",
-            "updated_at": "2021-02-22T21:15:57Z"
-         },
-         "entity": {
-            "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
-            "organization_guid": "my-org-guid",
-            "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
-            "organization_url": "/v2/organizations/my-org-guid"
-         }
-      }
-   ]
-}
-    """
-    fake_requests.get(
-        "http://localhost/v2/service_plan_visibilities?q=organization_guid:my-org-id&q=service_plan_guid:FAKE-MIGRATION-PLAN-GUID",
-        text=service_visibilities_response,
-    )
     response_body = ""
     fake_requests.delete(
-        "http://localhost/v2/service_plan_visibilities/my-service-plan-visibility",
+        "http://localhost/v3/service_plans/FAKE-MIGRATION-PLAN-GUID/visibility/my-org-id",
         text=response_body,
     )
 
@@ -1194,7 +1155,7 @@ def test_migration_migrates_happy_path(
 
     assert (
         fake_requests.request_history[3].url
-        == "http://localhost/v2/service_plan_visibilities"
+        == "http://localhost/v3/service_plans/FAKE-MIGRATION-PLAN-GUID/visibility"
     )
     assert fake_requests.request_history[3].method == "POST"
 
@@ -1220,29 +1181,24 @@ def test_migration_migrates_happy_path(
     assert fake_requests.request_history[7].method == "GET"
     assert (
         fake_requests.request_history[8].url
-        == "http://localhost/v2/service_plan_visibilities?q=organization_guid%3Amy-org-id&q=service_plan_guid%3AFAKE-MIGRATION-PLAN-GUID"
+        == "http://localhost/v3/service_plans/FAKE-MIGRATION-PLAN-GUID/visibility/my-org-id"
     )
-    assert fake_requests.request_history[8].method == "GET"
+    assert fake_requests.request_history[8].method == "DELETE"
+
     assert (
         fake_requests.request_history[9].url
-        == "http://localhost/v2/service_plan_visibilities/my-service-plan-visibility"
+        == "http://localhost/v2/service_instances/asdf-asdf?purge=true"
     )
     assert fake_requests.request_history[9].method == "DELETE"
 
+    assert fake_requests.request_history[10].method == "PUT"
     assert (
         fake_requests.request_history[10].url
-        == "http://localhost/v2/service_instances/asdf-asdf?purge=true"
-    )
-    assert fake_requests.request_history[10].method == "DELETE"
-
-    assert fake_requests.request_history[11].method == "PUT"
-    assert (
-        fake_requests.request_history[11].url
         == "http://localhost/v2/service_instances/my-migrator-instance?accepts_incomplete=true"
     )
-    assert fake_requests.request_history[12].method == "GET"
+    assert fake_requests.request_history[11].method == "GET"
     assert (
-        fake_requests.request_history[12].url
+        fake_requests.request_history[11].url
         == "http://localhost/v2/service_instances/my-migrator-instance"
     )
 

--- a/tests/integration/test_migration.py
+++ b/tests/integration/test_migration.py
@@ -290,34 +290,30 @@ def test_migration_enables_plan_in_org(
     clean_db, fake_cf_client, fake_requests, migration
 ):
     def service_plan_visibility_matcher(request):
-        params = request.json()
-        plan = "FAKE-MIGRATION-PLAN-GUID"
-        return (
-            params["organization_guid"] == "my-org-guid"
-            and params["service_plan_guid"] == plan
-        )
+       # params = request.json()
+       # plan = "FAKE-MIGRATION-PLAN-GUID"
+       # return (
+       #     params["organization_guid"] == "my-org-guid"
+       #     and params["service_plan_guid"] == plan
+       # )
+       return True
 
     migration._space_id = "my-space-guid"
     migration._org_id = "my-org-guid"
 
     response_body = """
 {
-  "metadata": {
-    "guid": "my-service-plan-visibility",
-    "url": "/v2/service_plan_visibilities/my-service-plan-visibility",
-    "created_at": "2016-06-08T16:41:31Z",
-    "updated_at": "2016-06-08T16:41:26Z"
-  },
-  "entity": {
-    "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
-    "organization_guid": "my-org-guid",
-    "service_plan_url": "/v2/service_plans/ab5780a9-ac8e-4412-9496-4512e865011a",
-    "organization_url": "/v2/organizations/my-org-guid"
-  }
+  "type": "organization",
+  "organizations": [
+    {
+      "guid": "my-org-id",
+      "name": "other_org"
+    }
+  ]
 }
     """
     fake_requests.post(
-        "http://localhost/v2/service_plan_visibilities",
+        "http://localhost/v3/service_plans/FAKE-MIGRATION-PLAN-GUID/visibility",
         text=response_body,
         additional_matcher=service_plan_visibility_matcher,
     )
@@ -326,7 +322,7 @@ def test_migration_enables_plan_in_org(
 
     assert fake_requests.called
     last_request = fake_requests.request_history[-1]
-    assert last_request.url == "http://localhost/v2/service_plan_visibilities"
+    assert last_request.url == "http://localhost/v3/service_plans/FAKE-MIGRATION-PLAN-GUID/visibility"
 
 
 def test_migration_disables_plan_in_org(
@@ -335,38 +331,9 @@ def test_migration_disables_plan_in_org(
     migration._space_id = "my-space-guid"
     migration._org_id = "my-org-guid"
 
-    response_body_get = """
-{
-   "total_results": 1,
-   "total_pages": 1,
-   "prev_url": null,
-   "next_url": null,
-   "resources": [
-      {
-         "metadata": {
-            "guid": "my-service-plan-visibility",
-            "url": "/v2/service_plan_visibilities/my-service-plan-visibility",
-            "created_at": "2021-02-22T21:15:57Z",
-            "updated_at": "2021-02-22T21:15:57Z"
-         },
-         "entity": {
-            "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
-            "organization_guid": "my-org-guid",
-            "service_plan_url": "/v2/service_plans/FAKE-MIGRATION-PLAN-GUID",
-            "organization_url": "/v2/organizations/my-org-guid"
-         }
-      }
-   ]
-}
-    """
-    fake_requests.get(
-        "http://localhost/v2/service_plan_visibilities?q=organization_guid:my-org-guid&q=service_plan_guid:FAKE-MIGRATION-PLAN-GUID",
-        text=response_body_get,
-    )
-
     response_body_delete = ""
     fake_requests.delete(
-        "http://localhost/v2/service_plan_visibilities/my-service-plan-visibility",
+        "http://localhost/v3/service_plans/FAKE-MIGRATION-PLAN-GUID/visibility/my-org-guid",
         text=response_body_delete,
     )
 
@@ -376,7 +343,7 @@ def test_migration_disables_plan_in_org(
     last_request = fake_requests.request_history[-1]
     assert (
         last_request.url
-        == "http://localhost/v2/service_plan_visibilities/my-service-plan-visibility"
+        == "http://localhost/v3/service_plans/FAKE-MIGRATION-PLAN-GUID/visibility/my-org-guid"
     )
 
 

--- a/tests/integration/test_migration.py
+++ b/tests/integration/test_migration.py
@@ -290,13 +290,8 @@ def test_migration_enables_plan_in_org(
     clean_db, fake_cf_client, fake_requests, migration
 ):
     def service_plan_visibility_matcher(request):
-       # params = request.json()
-       # plan = "FAKE-MIGRATION-PLAN-GUID"
-       # return (
-       #     params["organization_guid"] == "my-org-guid"
-       #     and params["service_plan_guid"] == plan
-       # )
-       return True
+       params = request.json()
+       return (params.get("organizations", [{}])[0].get("guid")== "my-org-guid")
 
     migration._space_id = "my-space-guid"
     migration._org_id = "my-org-guid"

--- a/tests/unit/test_cf.py
+++ b/tests/unit/test_cf.py
@@ -15,29 +15,24 @@ def test_get_client(fake_requests):
     client = get_test_client(fake_requests)
 
 
-def test_enable_service_plan_2(fake_requests, fake_cf_client):
+def test_enable_service_plan(fake_requests, fake_cf_client):
     response_body = """{
-  "metadata": {
-    "guid": "new-plan-visibility-guid",
-    "url": "/v2/service_plan_visibilities/new-plan-visibility-guid",
-    "created_at": "2016-06-08T16:41:31Z",
-    "updated_at": "2016-06-08T16:41:26Z"
-  },
-  "entity": {
-    "service_plan_guid": "foo",
-    "organization_guid": "bar",
-    "service_plan_url": "/v2/service_plans/foo",
-    "organization_url": "/v2/organizations/bar"
-  }
-}"""
+  "type": "organization",
+  "organizations": [
+    {
+      "guid": "bar",
+      "name": "other_org"
+    }
+  ]
+}}"""
     fake_requests.post(
-        "http://localhost/v2/service_plan_visibilities", text=response_body
+        "http://localhost/v3/service_plans/foo/visibility", text=response_body
     )
     res = cf.enable_plan_for_org("foo", "bar", fake_cf_client)
 
     assert fake_requests.called
     last_request = fake_requests.request_history[-1]
-    assert last_request.url == "http://localhost/v2/service_plan_visibilities"
+    assert last_request.url == "http://localhost/v3/service_plans/foo/visibility"
 
 
 def test_enable_service_plan_2(fake_requests, fake_cf_client):
@@ -48,7 +43,7 @@ def test_enable_service_plan_2(fake_requests, fake_cf_client):
     }
     """
     fake_requests.post(
-        "http://localhost/v2/service_plan_visibilities",
+        "http://localhost/v3/service_plans/foo/visibility",
         text=response_body,
         status_code=400,
     )
@@ -58,22 +53,22 @@ def test_enable_service_plan_2(fake_requests, fake_cf_client):
 
     assert fake_requests.called
     last_request = fake_requests.request_history[-1]
-    assert last_request.url == "http://localhost/v2/service_plan_visibilities"
+    assert last_request.url == "http://localhost/v3/service_plans/foo/visibility"
 
 
 def test_disable_service_plan_2(fake_requests, fake_cf_client):
     response_body = ""
     fake_requests.delete(
-        "http://localhost/v2/service_plan_visibilities/new-plan-visibility-guid",
+        "http://localhost/v3/service_plans/FAKE-MIGRATION-PLAN-GUID/visibility/test-org-id",
         text=response_body,
     )
-    res = cf.disable_plan_for_org("new-plan-visibility-guid", fake_cf_client)
+    res = cf.disable_plan_for_org("FAKE-MIGRATION-PLAN-GUID", "test-org-id", fake_cf_client)
 
     assert fake_requests.called
     last_request = fake_requests.request_history[-1]
     assert (
         last_request.url
-        == "http://localhost/v2/service_plan_visibilities/new-plan-visibility-guid"
+        == "http://localhost/v3/service_plans/FAKE-MIGRATION-PLAN-GUID/visibility/test-org-id"
     )
 
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Upgrade v2/service_plan_visibilities calls to v3/service_plan/:plan/visibility


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No direct security considerations here. Removing calls to CAPI v2 will make sure we can keep upgrading CF as needed, which is a security bonus.