### PR TITLE
Bb/more v3 stuff

### DIFF
--- a/migrator/cf.py
+++ b/migrator/cf.py
@@ -69,17 +69,16 @@ def create_bare_migrator_service_instance_in_space(
     return job_id
 
 
-#def get_migrator_service_instance_status(instance_id, client):
-#    logger.debug("polling service instance status for instance %s", instance_id)
-#    response = client.v2.service_instances.get(instance_id)
-#    return response["entity"]["last_operation"]["state"]
-
-
-def wait_for_service_instance_ready(job_id, client):
+def wait_for_job_complete(job_id, client):
     logger.debug("polling service instance status for instance %s", job_id)
     response = client.v3.jobs.wait_for_job_completion(job_id)
     if response['state'] != "COMPLETE":
         raise Exception(f"Job failed {response}")
+    return response
+    
+
+def wait_for_service_instance_create(job_id, client):
+    response = wait_for_job_complete(job_id, client)
     service_instance_link = response["links"]["service_instances"]["href"]
     service_instance_id = service_instance_link.split("/")[-1]
     return service_instance_id

--- a/migrator/migration.py
+++ b/migrator/migration.py
@@ -222,9 +222,15 @@ class Migration:
 
         raise Exception("Checking migrator service instance timed out.")
 
+    def wait_for_instance_update(self, job_id):
+        try:
+            return cf.wait_for_job_complete(job_id, self.client)
+        except JobTimeout as e:
+            raise Exception("Checking migrator service instance timed out.") from e
+
     def wait_for_instance_create(self, job_id):
         try:
-            return cf.wait_for_service_instance_ready(job_id, self.client)
+            return cf.wait_for_service_instance_create(job_id, self.client)
         except JobTimeout as e:
             raise Exception("Checking migrator service instance timed out.") from e
 
@@ -238,7 +244,7 @@ class Migration:
             self.client,
             new_instance_name=self.instance_name,
         )
-        return self.wait_for_instance_create(job_id)
+        return self.wait_for_instance_update(job_id)
 
     def mark_complete(self):
         self.route.state = "migrated"
@@ -388,7 +394,7 @@ class CdnMigration(Migration):
             new_plan_guid=config.CDN_PLAN_ID,
         )
 
-        self.wait_for_instance_create(job_id)
+        self.wait_for_instance_update(job_id)
 
     def _migrate(self):
         self.enable_migration_service_plan()
@@ -450,7 +456,7 @@ class DomainMigration(Migration):
             new_plan_guid=config.DOMAIN_PLAN_ID,
         )
 
-        self.wait_for_instance_create(job_id)
+        self.wait_for_instance_update(job_id)
 
     def _migrate(self):
         self.enable_migration_service_plan()

--- a/tests/integration/test_cdn_migration.py
+++ b/tests/integration/test_cdn_migration.py
@@ -2,6 +2,7 @@ import datetime
 from unittest.mock import call
 
 import pytest
+from cloudfoundry_client.v3.jobs import JobTimeout
 
 from migrator.migration import find_active_instances, CdnMigration
 from migrator.models import CdnRoute, CdnCertificate
@@ -232,11 +233,12 @@ def test_update_existing_cdn_domain(clean_db, fake_cf_client, cdn_migration, moc
     }
 
     update_mock = mocker.patch(
-        "migrator.migration.cf.update_existing_cdn_domain_service_instance"
+        "migrator.migration.cf.update_existing_cdn_domain_service_instance",
+        return_value="my-job-id"
     )
     update_instance_wait_mock = mocker.patch(
-        "migrator.migration.cf.get_migrator_service_instance_status",
-        return_value="succeeded",
+        "migrator.migration.cf.wait_for_service_instance_ready",
+        return_value="my-migrator-instance",
     )
 
     cdn_migration.update_existing_cdn_domain()
@@ -269,7 +271,7 @@ def test_update_existing_cdn_domain(clean_db, fake_cf_client, cdn_migration, moc
         new_plan_guid="FAKE-CDN-PLAN-GUID",
     )
     update_instance_wait_mock.assert_called_once_with(
-        "my-migrator-instance", fake_cf_client
+        "my-job-id", fake_cf_client
     )
 
 
@@ -342,15 +344,16 @@ def test_update_existing_cdn_domain_failure(
     }
 
     update_mock = mocker.patch(
-        "migrator.migration.cf.update_existing_cdn_domain_service_instance"
+        "migrator.migration.cf.update_existing_cdn_domain_service_instance",
+        return_value="my-cursed-job-id"
     )
     update_instance_wait_mock = mocker.patch(
-        "migrator.migration.cf.get_migrator_service_instance_status",
-        return_value="failed",
+        "migrator.migration.cf.wait_for_service_instance_ready",
+        side_effect=Exception(f"Job failed {dict(state='no good')}")
     )
 
     with pytest.raises(
-        Exception, match="Creation of migrator service instance failed."
+        Exception, match="Job failed"
     ):
         cdn_migration.update_existing_cdn_domain()
 
@@ -382,7 +385,7 @@ def test_update_existing_cdn_domain_failure(
         new_plan_guid="FAKE-CDN-PLAN-GUID",
     )
     update_instance_wait_mock.assert_called_once_with(
-        "my-migrator-instance", fake_cf_client
+        "my-cursed-job-id", fake_cf_client
     )
 
 
@@ -455,14 +458,15 @@ def test_update_existing_cdn_domain_timeout_failure(
     }
 
     update_mock = mocker.patch(
-        "migrator.migration.cf.update_existing_cdn_domain_service_instance"
+        "migrator.migration.cf.update_existing_cdn_domain_service_instance",
+        return_value="my-unending-job"
     )
 
     # with this setup this mock will return "in progess" as many times as we call it
     # then later we 1: check that we got the expected exception and 2: that we called it the expected number of times
     update_instance_wait_mock = mocker.patch(
-        "migrator.migration.cf.get_migrator_service_instance_status",
-        return_value="in progress",
+        "migrator.migration.cf.wait_for_service_instance_ready",
+        side_effect=JobTimeout
     )
 
     with pytest.raises(
@@ -497,15 +501,9 @@ def test_update_existing_cdn_domain_timeout_failure(
         fake_cf_client,
         new_plan_guid="FAKE-CDN-PLAN-GUID",
     )
-    update_instance_wait_mock.assert_has_calls(
-        [
-            call("my-migrator-instance", fake_cf_client),
-            call("my-migrator-instance", fake_cf_client),
-        ]
+    update_instance_wait_mock.assert_called_once_with(
+            "my-unending-job", fake_cf_client
     )
-    # make sure we tried the right number of times, which is
-    # config.SERVICE_CHANGE_RETRY_COUNT
-    assert update_instance_wait_mock.call_count == 2
 
 
 def test_migration_migrates_happy_path(
@@ -629,11 +627,8 @@ def test_migration_migrates_happy_path(
         return_value="my-instance-id",
     )
     update_service_instance_mock = mocker.patch(
-        "migrator.migration.cf.update_existing_cdn_domain_service_instance"
-    )
-    update_instance_wait_mock = mocker.patch(
-        "migrator.migration.cf.get_migrator_service_instance_status",
-        return_value="succeeded",
+        "migrator.migration.cf.update_existing_cdn_domain_service_instance",
+        return_value="my-second-job"
     )
 
     disable_service_mock = mocker.patch("migrator.migration.cf.disable_plan_for_org")
@@ -658,7 +653,7 @@ def test_migration_migrates_happy_path(
     )
 
     # wait for service instance
-    wait_mock.assert_called_once_with("my-job", fake_cf_client)
+    wait_mock.assert_has_calls([call("my-job", fake_cf_client),call("my-second-job", fake_cf_client)])
 
     # update service instance
     update_service_instance_mock.assert_has_calls(
@@ -696,14 +691,6 @@ def test_migration_migrates_happy_path(
         ]
     )
 
-    update_instance_wait_mock.assert_has_calls(
-        [
-            # wait for instance type change
-            call("my-instance-id", fake_cf_client),
-            # wait for instance rename
-            call("my-instance-id", fake_cf_client),
-        ]
-    )
 
     # delete service plan visibility
     disable_service_mock.assert_called_once_with(

--- a/tests/integration/test_domain_migration.py
+++ b/tests/integration/test_domain_migration.py
@@ -128,11 +128,8 @@ def test_domain_migration_migrates(
 
     # these two functions are called more than once. The way mocking works means we define them once then check their calls later
     update_service_instance_mock = mocker.patch(
-        "migrator.migration.cf.update_existing_cdn_domain_service_instance"
-    )
-    update_instance_wait_mock = mocker.patch(
-        "migrator.migration.cf.get_migrator_service_instance_status",
-        return_value="succeeded",
+        "migrator.migration.cf.update_existing_cdn_domain_service_instance",
+        return_value="my-second-job"
     )
 
     disable_service_mock = mocker.patch("migrator.migration.cf.disable_plan_for_org")
@@ -157,7 +154,7 @@ def test_domain_migration_migrates(
     )
 
     # wait for service instance
-    wait_mock.assert_called_once_with("my-job", fake_cf_client)
+    wait_mock.assert_has_calls([call("my-job", fake_cf_client),call("my-second-job", fake_cf_client)])
 
     # update service instance
     update_service_instance_mock.assert_has_calls(
@@ -184,14 +181,6 @@ def test_domain_migration_migrates(
         ]
     )
 
-    update_instance_wait_mock.assert_has_calls(
-        [
-            # wait for instance type change
-            call("my-instance-id", fake_cf_client),
-            # wait for instance rename
-            call("my-instance-id", fake_cf_client),
-        ]
-    )
 
     # delete service plan visibility
     disable_service_mock.assert_called_once_with(

--- a/tests/integration/test_domain_migration.py
+++ b/tests/integration/test_domain_migration.py
@@ -121,15 +121,17 @@ def test_domain_migration_migrates(
         "migrator.migration.cf.create_bare_migrator_service_instance_in_space",
         return_value="my-job",
     )
-    wait_mock = mocker.patch(
-        "migrator.migration.cf.wait_for_service_instance_ready",
+    create_wait_mock = mocker.patch(
+        "migrator.migration.cf.wait_for_service_instance_create",
         return_value="my-instance-id",
     )
-
-    # these two functions are called more than once. The way mocking works means we define them once then check their calls later
     update_service_instance_mock = mocker.patch(
         "migrator.migration.cf.update_existing_cdn_domain_service_instance",
-        return_value="my-second-job"
+        side_effect=["my-second-job", "my-third-job"]
+    )
+    update_wait_mock = mocker.patch(
+        "migrator.migration.cf.wait_for_job_complete",
+        return_value={}, # it's a complex object in reality, but we ignore it
     )
 
     disable_service_mock = mocker.patch("migrator.migration.cf.disable_plan_for_org")
@@ -154,7 +156,7 @@ def test_domain_migration_migrates(
     )
 
     # wait for service instance
-    wait_mock.assert_has_calls([call("my-job", fake_cf_client),call("my-second-job", fake_cf_client)])
+    create_wait_mock.assert_called_once_with("my-job", fake_cf_client)
 
     # update service instance
     update_service_instance_mock.assert_has_calls(
@@ -180,6 +182,11 @@ def test_domain_migration_migrates(
             ),
         ]
     )
+
+    update_wait_mock.assert_has_calls([
+        call("my-second-job", fake_cf_client),
+        call("my-third-job", fake_cf_client)
+    ])
 
 
     # delete service plan visibility

--- a/tests/integration/test_migration.py
+++ b/tests/integration/test_migration.py
@@ -273,7 +273,7 @@ def test_create_bare_migrator_instance_in_org_space_success(
         return_value="my-job",
     )
     wait_mocker = mocker.patch(
-        "migrator.migration.cf.wait_for_service_instance_ready",
+        "migrator.migration.cf.wait_for_service_instance_create",
         return_value="my-instance-id",
     )
     migration.create_bare_migrator_instance_in_org_space()
@@ -295,8 +295,8 @@ def test_migration_renames_instance(clean_db, fake_cf_client, migration, mocker)
         return_value="my-job-id"
     )
     instance_status_mock = mocker.patch(
-        "migrator.migration.cf.wait_for_service_instance_ready",
-        return_value="migrator-instance-id",
+        "migrator.migration.cf.wait_for_job_complete",
+        return_value={} # the return is a complex dict, but we ignore it
     )
     migration.external_domain_broker_service_instance = "migrator-instance-id"
     migration.update_instance_name()

--- a/tests/integration/test_migration.py
+++ b/tests/integration/test_migration.py
@@ -291,11 +291,12 @@ def test_create_bare_migrator_instance_in_org_space_success(
 
 def test_migration_renames_instance(clean_db, fake_cf_client, migration, mocker):
     update_service_instance_mock = mocker.patch(
-        "migrator.migration.cf.update_existing_cdn_domain_service_instance"
+        "migrator.migration.cf.update_existing_cdn_domain_service_instance",
+        return_value="my-job-id"
     )
     instance_status_mock = mocker.patch(
-        "migrator.migration.cf.get_migrator_service_instance_status",
-        return_value="succeeded",
+        "migrator.migration.cf.wait_for_service_instance_ready",
+        return_value="migrator-instance-id",
     )
     migration.external_domain_broker_service_instance = "migrator-instance-id"
     migration.update_instance_name()
@@ -303,7 +304,7 @@ def test_migration_renames_instance(clean_db, fake_cf_client, migration, mocker)
         "migrator-instance-id", {}, fake_cf_client, new_instance_name="my-old-cdn"
     )
 
-    instance_status_mock.assert_called_once_with("migrator-instance-id", fake_cf_client)
+    instance_status_mock.assert_called_once_with("my-job-id", fake_cf_client)
 
 
 def test_migration_marks_route_migrated(clean_db, fake_cf_client, migration):

--- a/tests/unit/test_cf.py
+++ b/tests/unit/test_cf.py
@@ -76,47 +76,68 @@ def test_disable_service_plan_2(fake_requests, fake_cf_client):
 
 def test_get_space_for_instance(migration, fake_requests, fake_cf_client):
     response_body = """
-    {
-  "metadata": {
-    "guid": "some-instance-id",
-    "url": "/v2/service_instances/some-instance-id",
-    "created_at": "2016-06-08T16:41:29Z",
-    "updated_at": "2016-06-08T16:41:26Z"
+   {
+  "guid": "asdf-asdf",
+  "created_at": "2020-03-10T15:49:29Z",
+  "updated_at": "2020-03-10T15:49:29Z",
+  "name": "my-managed-instance",
+  "tags": [],
+  "type": "managed",
+  "maintenance_info": {
+    "version": "1.0.0"
   },
-  "entity": {
-    "name": "name-1508",
-    "service_guid": "a14baddf-1ccc-5299-0152-ab9s49de4422",
-    "service_plan_guid": "779d2df0-9cdd-48e8-9781-ea05301cedb1",
-    "space_guid": "my-space-guid",
-    "gateway_data": null,
-    "dashboard_url": null,
-    "type": "managed_service_instance",
-    "last_operation": {
-      "type": "create",
-      "state": "succeeded",
-      "description": "service broker-provided description",
-      "updated_at": "2016-06-08T16:41:29Z",
-      "created_at": "2016-06-08T16:41:29Z"
+  "upgrade_available": false,
+  "dashboard_url": "https://service-broker.example.org/dashboard",
+  "last_operation": {
+    "type": "create",
+    "state": "succeeded",
+    "description": "Operation succeeded",
+    "updated_at": "2020-03-10T15:49:32Z",
+    "created_at": "2020-03-10T15:49:29Z"
+  },
+  "relationships": {
+    "service_plan": {
+      "data": {
+        "guid": "5358d122-638e-11ea-afca-bf6e756684ac"
+      }
     },
-    "tags": [ ],
-    "maintenance_info": {
-      "version": "2.1.1",
-      "description": "OS image update.Expect downtime."
+    "space": {
+      "data": {
+        "guid": "my-space-guid"
+      }
+    }
+  },
+  "metadata": {
+    "labels": {},
+    "annotations": {}
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/service_instances/asdf-asdf"
     },
-    "space_url": "/v2/spaces/my-space-guid",
-    "service_url": "/v2/services/a14baddf-1ccc-5299-0152-ab9s49de4422",
-    "service_plan_url": "/v2/service_plans/779d2df0-9cdd-48e8-9781-ea05301cedb1",
-    "service_bindings_url": "/v2/service_instances/some-instance-id/service_bindings",
-    "service_keys_url": "/v2/service_instances/some-instance-id/service_keys",
-    "routes_url": "/v2/service_instances/some-instance-id/routes",
-    "shared_from_url": "/v2/service_instances/some-instance-id/shared_from",
-    "shared_to_url": "/v2/service_instances/some-instance-id/shared_to",
-    "service_instance_parameters_url": "/v2/service_instances/some-instance-id/parameters"
+    "service_plan": {
+      "href": "https://api.example.org/v3/service_plans/5358d122-638e-11ea-afca-bf6e756684ac"
+    },
+    "space": {
+      "href": "https://api.example.org/v3/spaces/my-space-guid"
+    },
+    "parameters": {
+      "href": "https://api.example.org/v3/service_instances/asdf-asdf/parameters"
+    },
+    "shared_spaces": {
+      "href": "https://api.example.org/v3/service_instances/asdf-asdf/relationships/shared_spaces"
+    },
+    "service_credential_bindings": {
+      "href": "https://api.example.org/v3/service_credential_bindings?service_instance_guids=asdf-asdf"
+    },
+    "service_route_bindings": {
+      "href": "https://api.example.org/v3/service_route_bindings?service_instance_guids=asdf-asdf"
+    }
   }
 }
 """
     fake_requests.get(
-        "http://localhost/v2/service_instances/asdf-asdf", text=response_body
+        "http://localhost/v3/service_instances/asdf-asdf", text=response_body
     )
     assert (
         cf.get_space_id_for_service_instance_id(migration.instance_id, fake_cf_client)
@@ -125,7 +146,7 @@ def test_get_space_for_instance(migration, fake_requests, fake_cf_client):
 
     assert fake_requests.called
     last_request = fake_requests.request_history[-1]
-    assert last_request.url == "http://localhost/v2/service_instances/asdf-asdf"
+    assert last_request.url == "http://localhost/v3/service_instances/asdf-asdf"
 
 
 def test_get_org_id_for_space_id(fake_cf_client, fake_requests):
@@ -396,70 +417,116 @@ def test_wait_for_instance_ready(fake_cf_client, fake_requests):
     )
 
 
-def update_existing_cdn_domain_service_instance(fake_cf_client, fake_requests):
-    response_body = """
-{
-  "metadata": {
-    "guid": "my-migrator-instance",
-    "url": "/v2/service_instances/my-migrator-instance",
-    "created_at": "2016-06-08T16:41:30Z",
-    "updated_at": "2016-06-08T16:41:26Z"
-  },
-  "entity": {
-    "name": "external-domain-broker-migrator",
-    "credentials": {
-      "creds-key-41": "creds-val-41"
-    },
-    "service_plan_guid": "739e78F5-a919-46ef-9193-1293cc086c17",
-    "space_guid": "my-space-guid",
-    "gateway_data": null,
-    "dashboard_url": null,
-    "type": "managed_service_instance",
-    "last_operation": {
-      "type": "update",
-      "state": "in progress",
-      "description": "",
-      "updated_at": "2016-06-08T16:41:30Z",
-      "created_at": "2016-06-08T16:41:30Z"
-    },
-    "tags": [
-
-    ],
-    "maintenance_info": {
-      "version": "2.1.0",
-      "description": "OS image update.\nExpect downtime."
-    },
-    "space_url": "/v2/spaces/my-space-guid",
-    "service_plan_url": "/v2/service_plans/739e78F5-a919-46ef-9193-1293cc086c17",
-    "service_bindings_url": "/v2/service_instances/my-migrator-instance/service_bindings",
-    "service_keys_url": "/v2/service_instances/my-migrator-instance/service_keys",
-    "routes_url": "/v2/service_instances/my-migrator-instance/routes",
-    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
-    "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
-  }
-}
+def test_wait_for_instance_ready_but_it_fails(fake_cf_client, fake_requests):
+    job_response_body_processing = """
+    {
+      "created_at": "2025-04-21T23:35:27Z",
+      "errors": [],
+      "guid": "create-instance-job-guid",
+      "links": {
+        "self": {
+          "href": "https://api.fr.cloud.gov/v3/jobs/create-instance-job-guid"
+        },
+        "service_instances": {
+          "href": "https://api.fr.cloud.gov/v3/service_instances/my-service-instance-id"
+        }
+      },
+      "operation": "service_instance.create",
+      "state": "PROCESSING",
+      "updated_at": "2025-04-21T23:35:27Z",
+      "warnings": []
+    }
+    """
+    job_response_body_polling = """
+    {
+      "created_at": "2025-04-21T23:35:27Z",
+      "errors": [],
+      "guid": "create-instance-job-guid",
+      "links": {
+        "self": {
+          "href": "https://api.fr.cloud.gov/v3/jobs/create-instance-job-id"
+        },
+        "service_instances": {
+          "href": "https://api.fr.cloud.gov/v3/service_instances/my-service-instance-id"
+        }
+      },
+      "operation": "service_instance.create",
+      "state": "POLLING",
+      "updated_at": "2025-04-21T23:35:29Z",
+      "warnings": []
+    }
+    """
+    job_response_body_failed = """
+    {
+      "created_at": "2025-04-21T23:35:27Z",
+      "errors": [],
+      "guid": "create-instance-job-guid",
+      "links": {
+        "self": {
+          "href": "https://api.fr.cloud.gov/v3/jobs/create-instance-job-id"
+        },
+        "service_instances": {
+          "href": "https://api.fr.cloud.gov/v3/service_instances/my-service-instance-id"
+        }
+      },
+      "operation": "service_instance.create",
+      "state": "FAILED",
+      "updated_at": "2025-04-21T23:41:31Z",
+      "warnings": []
+    }
     """
 
-    fake_requests.put(
-        "http://localhost/v2/service_instances/my-migrator-instance", text=response_body
+    fake_requests.get(
+        "http://localhost/v3/jobs/create-instance-job-id",
+        text=job_response_body_processing,
+    )
+    fake_requests.get(
+        "http://localhost/v3/jobs/create-instance-job-id",
+        text=job_response_body_polling,
+    )
+    fake_requests.get(
+        "http://localhost/v3/jobs/create-instance-job-id",
+        text=job_response_body_polling,
+    )
+    fake_requests.get(
+        "http://localhost/v3/jobs/create-instance-job-id",
+        text=job_response_body_failed,
+    )
+
+    with pytest.raises(Exception, match="Job failed"):
+        cf.wait_for_service_instance_ready("create-instance-job-id", fake_cf_client)
+
+
+def test_update_existing_cdn_domain_service_instance(fake_cf_client, fake_requests):
+
+    def update_param_matcher(request):
+        json_ = request.json()
+        params = json_.get("parameters", {})
+        # use an assert for pytest
+        assert "param1" in params
+        # return True for requests_mock
+        return True
+
+    fake_requests.patch(
+        "http://localhost/v3/service_instances/my-migrator-instance", text="",
+        headers={"Location": "http://localhost/v3/jobs/job-id"},
+        additional_matcher=update_param_matcher
     )
 
     response = cf.update_existing_cdn_domain_service_instance(
-        "my-space-guid",
-        "739e78F5-a919-46ef-9193-1293cc086c17",
-        "external-domain-broker-migrator",
+        "my-migrator-instance",
+        {
+          "param1": "value1"
+        },
         fake_cf_client,
     )
 
     assert fake_requests.called
     last_request = fake_requests.request_history[-1]
     assert (
-        last_request.url == "http://localhost/v2/service_instances/my-migrator-instance"
+        last_request.url == "http://localhost/v3/service_instances/my-migrator-instance"
     )
-
-    assert response["guid"] == "my-migrator-instance"
-    assert response["state"] == "in progress"
-    assert response["type"] == "update"
+    assert response == "job-id"
 
 
 def test_purge_service_instance(fake_cf_client, fake_requests):


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update space-id fetching call to v3
- Update service-instance update calls to v3
- Separate waiter logic between create and update, since the job bodies are likely different.
- Rename a test that never had test in its name, so it will actually run 🤦🏻 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

The logging on instance update polling should probably be tightened, but I don't have the hours left to do it. Otherwise, no direct security implications. Indirectly, this helps us get off of CAPI v2, so when it is deprecated we can update in a timely manner