### PR TITLE
Fix minor typo in ./tests/integration/test_cdn_migration.py

### DIFF
--- a/tests/integration/test_cdn_migration.py
+++ b/tests/integration/test_cdn_migration.py
@@ -462,7 +462,7 @@ def test_update_existing_cdn_domain_timeout_failure(
         return_value="my-unending-job"
     )
 
-    # with this setup this mock will return "in progess" as many times as we call it
+    # with this setup this mock will return "in progress" as many times as we call it
     # then later we 1: check that we got the expected exception and 2: that we called it the expected number of times
     update_instance_wait_mock = mocker.patch(
         "migrator.migration.cf.wait_for_job_complete",


### PR DESCRIPTION
## Changes proposed in this pull request:

This PR fixes a minor spelling error in ./tests/integration/test_cdn_migration.py file

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None